### PR TITLE
Waveshare Fixes

### DIFF
--- a/src/omni_epd/displayfactory.py
+++ b/src/omni_epd/displayfactory.py
@@ -26,7 +26,7 @@ from . errors import EPDNotFoundError
 from . conf import CONFIG_FILE, EPD_CONFIG
 from . virtualepd import VirtualEPD
 from . displays.mock_display import MockDisplay  # noqa: F401
-from . displays.waveshare_display import WaveshareDisplay  # noqa: F401
+from . displays.waveshare_display import WaveshareDisplay, WaveshareTriColorDisplay, Waveshare102inDisplay, Waveshare3in7Display  # noqa: F401
 from . displays.inky_display import InkyDisplay, InkyImpressionDisplay  # noqa: F401
 
 

--- a/src/omni_epd/displays/inky_display.py
+++ b/src/omni_epd/displays/inky_display.py
@@ -66,15 +66,10 @@ class InkyDisplay(VirtualEPD):
                       "phat1608_black", "phat1608_red", "phat1608_yellow",
                       "what_black", "what_red", "what_yellow"]
 
-        try:
-            # do a test import from the inky library
-            from inky import WHITE  # noqa: F401
-
+        # python libs for this might not be installed - that's ok, return nothing
+        if(InkyDisplay.check_module_installed('inky')):
             # if passed return list of devices
             result = [f"{InkyDisplay.pkg_name}.{n}" for n in deviceList]
-        except ModuleNotFoundError:
-            # python libs for this might not be installed - that's ok, return nothing
-            pass
 
         return result
 
@@ -117,15 +112,10 @@ class InkyImpressionDisplay(VirtualEPD):
     def get_supported_devices():
         result = []
 
-        try:
-            # do a test import from the inky library
-            from inky.inky_uc8159 import CLEAN  # noqa: F401
-
+        # python libs for this might not be installed - that's ok, return nothing
+        if(InkyImpressionDisplay.check_module_installed('inky')):
             # if passed return list of devices
             result = [f"{InkyDisplay.pkg_name}.impression"]
-        except ModuleNotFoundError:
-            # python libs for this might not be installed - that's ok, return nothing
-            pass
 
         return result
 

--- a/src/omni_epd/displays/waveshare_display.py
+++ b/src/omni_epd/displays/waveshare_display.py
@@ -105,6 +105,72 @@ class WaveshareDisplay(VirtualEPD):
         epdconfig.module_init()
         epdconfig.module_exit()
 
+
+class WaveshareTriColorDisplay(VirtualEPD):
+    """
+    This class is for the Waveshare displays that support 3 colors
+    typically white/black/red or white/black/yellow
+    https://github.com/waveshare/e-Paper
+    """
+
+    pkg_name = 'waveshare_epd'
+
+    def __init__(self, deviceName, config):
+        super(MockDisplay, self).__init__(deviceName, config)
+
+        deviceObj = self.load_display_driver(self.pkg_name, deviceName)
+
+        # create the epd object
+        self._device = deviceObj.EPD()
+
+        # set the width and height
+        self.width = self._device.width
+        self.height = self._device.height
+
+    def _createEmptyImage(self):
+        return Image.new('L', [self.width, self.height], 255)
+
+    @staticmethod
+    def get_supported_devices():
+        result = []
+
+        deviceList = ["epd1in54b", "epd1in54b_V2", "epd1in54c",
+                      "epd2in13b_V3", "epd2in13bc", "epd2in66b",
+                      "epd2in7b", "epd2in7b_V2", "epd2in9b_V3",
+                      "epd2in9bc", "epd4in2b_V2", "epd4in2bc",
+                      "epd5in83b_V2", "epd5in83bc", "epd7in5b_HD",
+                      "epd7in5b_V2", "epd7in5bc"]
+
+        try:
+            from waveshare_epd import epdconfig
+
+            result = [f"{WaveshareTriColorDisplay.pkg_name}.{n}" for n in deviceList]
+        except ModuleNotFoundError:
+            # python libs for this might not be installed - that's ok, return nothing
+            pass
+
+        return result
+
+    def prepare(self):
+        self._device.init()
+
+    def _display(self, image):
+        # send the black/white image and blank second image (safer since some require data)
+        self._device.display(self._device.getbuffer(image), self._device.getbuffer(self._createEmptyImage()))
+
+    def sleep(self):
+        self._device.sleep()
+
+    def clear(self):
+        self._device.Clear()
+
+    def close(self):
+        # can't import this earlier as pkg may not be installed
+        from waveshare_epd import epdconfig
+        epdconfig.module_init()
+        epdconfig.module_exit()
+
+
 class Waveshare102inDisplay(VirtualEPD):
     """
     This class is for the Waveshare 1.02 in display only as it has some method calls that are different

--- a/src/omni_epd/displays/waveshare_display.py
+++ b/src/omni_epd/displays/waveshare_display.py
@@ -147,7 +147,7 @@ class WaveshareTriColorDisplay(VirtualEPD):
 
     def _display(self, image):
         # send the black/white image and blank second image (safer since some require data)
-        self._device.display(self._device.getbuffer(image), self._device.getbuffer(self._createEmptyImage()))
+        self._device.display(self._device.getbuffer(image), [0x00] * (int(self.width/8) * self.height)))
 
     def sleep(self):
         self._device.sleep()

--- a/src/omni_epd/displays/waveshare_display.py
+++ b/src/omni_epd/displays/waveshare_display.py
@@ -156,3 +156,57 @@ class Waveshare102inDisplay(VirtualEPD):
         from waveshare_epd import epdconfig
         epdconfig.module_init()
         epdconfig.module_exit()
+
+class Waveshare3in7Display(VirtualEPD):
+    """
+    This class is for the Waveshare 3.7in display only as it
+    has support for different gray scales and the methods are different
+    https://github.com/waveshare/e-Paper/blob/master/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd3in7.py
+    """
+
+    pkg_name = 'waveshare_epd'
+
+    def __init__(self, deviceName, config):
+        super(MockDisplay, self).__init__(deviceName, config)
+
+        deviceObj = self.load_display_driver(self.pkg_name, deviceName)
+
+        # create the epd object
+        self._device = deviceObj.EPD()
+
+        # set the width and height
+        self.width = self._device.width
+        self.height = self._device.height
+
+    @staticmethod
+    def get_supported_devices():
+        result = []
+
+        try:
+            from waveshare_epd import epdconfig
+
+            result = [f"{Waveshare102inDisplay.pkg_name}.epd3in7"]
+        except ModuleNotFoundError:
+            # python libs for this might not be installed - that's ok, return nothing
+            pass
+
+        return result
+
+    def prepare(self):
+        # only b/w supported right now
+        self._device.init(1)
+
+    def _display(self, image):
+        self._device.display_1Gray(self._device.getbuffer(image))
+
+    def sleep(self):
+        self._device.sleep()
+
+    def clear(self):
+        self._device.Clear()
+
+    def close(self):
+        # can't import this earlier as pkg may not be installed
+        from waveshare_epd import epdconfig
+        epdconfig.module_init()
+        epdconfig.module_exit()

--- a/src/omni_epd/displays/waveshare_display.py
+++ b/src/omni_epd/displays/waveshare_display.py
@@ -104,3 +104,55 @@ class WaveshareDisplay(VirtualEPD):
         from waveshare_epd import epdconfig
         epdconfig.module_init()
         epdconfig.module_exit()
+
+class Waveshare102inDisplay(VirtualEPD):
+    """
+    This class is for the Waveshare 1.02 in display only as it has some method calls that are different
+    https://github.com/waveshare/e-Paper/blob/master/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd1in02.py
+    """
+
+    pkg_name = 'waveshare_epd'
+
+    def __init__(self, deviceName, config):
+        super(MockDisplay, self).__init__(deviceName, config)
+
+        deviceObj = self.load_display_driver(self.pkg_name, deviceName)
+
+        # create the epd object
+        self._device = deviceObj.EPD()
+
+        # set the width and height
+        self.width = self._device.width
+        self.height = self._device.height
+
+    @staticmethod
+    def get_supported_devices():
+        result = []
+
+        try:
+            from waveshare_epd import epdconfig
+
+            result = [f"{Waveshare102inDisplay.pkg_name}.epd1in02"]
+        except ModuleNotFoundError:
+            # python libs for this might not be installed - that's ok, return nothing
+            pass
+
+        return result
+
+    def prepare(self):
+        self._device.Init()
+
+    def _display(self, image):
+        self._device.Display(self._device.getbuffer(image))
+
+    def sleep(self):
+        self._device.Sleep()
+
+    def clear(self):
+        self._device.Clear()
+
+    def close(self):
+        # can't import this earlier as pkg may not be installed
+        from waveshare_epd import epdconfig
+        epdconfig.module_init()
+        epdconfig.module_exit()

--- a/src/omni_epd/displays/waveshare_display.py
+++ b/src/omni_epd/displays/waveshare_display.py
@@ -122,9 +122,6 @@ class WaveshareTriColorDisplay(VirtualEPD):
         self.width = self._device.width
         self.height = self._device.height
 
-    def _createEmptyImage(self):
-        return Image.new('L', [self.width, self.height], 255)
-
     @staticmethod
     def get_supported_devices():
         result = []

--- a/src/omni_epd/displays/waveshare_display.py
+++ b/src/omni_epd/displays/waveshare_display.py
@@ -70,9 +70,6 @@ class WaveshareDisplay(VirtualEPD):
 
         # python libs for this might not be installed - that's ok, return nothing
         if(WaveshareDisplay.check_module_installed('waveshare_epd')):
-            # load the waveshare library
-            from waveshare_epd import epdconfig  # noqa: F401
-
             result = result + commonDeviceList
 
             # return a list of all submodules (device types)

--- a/src/omni_epd/displays/waveshare_display.py
+++ b/src/omni_epd/displays/waveshare_display.py
@@ -18,7 +18,6 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 """
 
-from PIL import Image
 from .. virtualepd import VirtualEPD
 
 
@@ -144,7 +143,7 @@ class WaveshareTriColorDisplay(VirtualEPD):
 
     def _display(self, image):
         # send the black/white image and blank second image (safer since some require data)
-        self._device.display(self._device.getbuffer(image), [0x00] * (int(self.width/8) * self.height)))
+        self._device.display(self._device.getbuffer(image), [0x00] * (int(self.width/8) * self.height))
 
     def sleep(self):
         self._device.sleep()

--- a/src/omni_epd/displays/waveshare_display.py
+++ b/src/omni_epd/displays/waveshare_display.py
@@ -67,7 +67,9 @@ class WaveshareDisplay(VirtualEPD):
                             "epd2in9_V2", "epd2in9d", "epd4in01f",
                             "epd4in2", "epd5in65f", "epd5in83",
                             "epd5in83_V2", "epd7in5", "epd7in5_HD", "epd7in5_V2"]
-        try:
+
+        # python libs for this might not be installed - that's ok, return nothing
+        if(WaveshareDisplay.check_module_installed('waveshare_epd')):
             # load the waveshare library
             from waveshare_epd import epdconfig  # noqa: F401
 
@@ -75,9 +77,6 @@ class WaveshareDisplay(VirtualEPD):
 
             # return a list of all submodules (device types)
             result = [f"{WaveshareDisplay.pkg_name}.{n}" for n in result]
-        except ModuleNotFoundError:
-            # python libs for this might not be installed - that's ok, return nothing
-            pass
 
         return result
 
@@ -140,13 +139,9 @@ class WaveshareTriColorDisplay(VirtualEPD):
                       "epd5in83b_V2", "epd5in83bc", "epd7in5b_HD",
                       "epd7in5b_V2", "epd7in5bc"]
 
-        try:
-            from waveshare_epd import epdconfig  # noqa: F401
-
+        # python libs for this might not be installed - that's ok, return nothing
+        if(WaveshareTriColorDisplay.check_module_installed('waveshare_epd')):
             result = [f"{WaveshareTriColorDisplay.pkg_name}.{n}" for n in deviceList]
-        except ModuleNotFoundError:
-            # python libs for this might not be installed - that's ok, return nothing
-            pass
 
         return result
 
@@ -194,13 +189,8 @@ class Waveshare102inDisplay(VirtualEPD):
     def get_supported_devices():
         result = []
 
-        try:
-            from waveshare_epd import epdconfig  # noqa: F401
-
+        if(Waveshare102inDisplay.check_module_installed('waveshare_epd')):
             result = [f"{Waveshare102inDisplay.pkg_name}.epd1in02"]
-        except ModuleNotFoundError:
-            # python libs for this might not be installed - that's ok, return nothing
-            pass
 
         return result
 
@@ -248,13 +238,8 @@ class Waveshare3in7Display(VirtualEPD):
     def get_supported_devices():
         result = []
 
-        try:
-            from waveshare_epd import epdconfig  # noqa: F401
-
+        if(Waveshare3in7Display.check_module_installed('waveshare_epd')):
             result = [f"{Waveshare102inDisplay.pkg_name}.epd3in7"]
-        except ModuleNotFoundError:
-            # python libs for this might not be installed - that's ok, return nothing
-            pass
 
         return result
 

--- a/src/omni_epd/displays/waveshare_display.py
+++ b/src/omni_epd/displays/waveshare_display.py
@@ -18,8 +18,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 """
 
-import importlib
-from pkgutil import iter_modules
+from PIL import Image
 from .. virtualepd import VirtualEPD
 
 
@@ -65,12 +64,12 @@ class WaveshareDisplay(VirtualEPD):
 
         # list of common devices that share init() and display() method calls
         commonDeviceList = ["epd1in54_V2", "epd2in13d", "epd2in7",
-                      "epd2in9_V2", "epd2in9d", "epd4in01f",
-                      "epd4in2", "epd5in65f", "epd5in83",
-                      "epd5in83_V2", "epd7in5", "epd7in5_HD", "epd7in5_V2"]
+                            "epd2in9_V2", "epd2in9d", "epd4in01f",
+                            "epd4in2", "epd5in65f", "epd5in83",
+                            "epd5in83_V2", "epd7in5", "epd7in5_HD", "epd7in5_V2"]
         try:
             # load the waveshare library
-            from waveshare_epd import epdconfig
+            from waveshare_epd import epdconfig  # noqa: F401
 
             result = result + commonDeviceList
 
@@ -116,7 +115,7 @@ class WaveshareTriColorDisplay(VirtualEPD):
     pkg_name = 'waveshare_epd'
 
     def __init__(self, deviceName, config):
-        super(MockDisplay, self).__init__(deviceName, config)
+        super(WaveshareTriColorDisplay, self).__init__(deviceName, config)
 
         deviceObj = self.load_display_driver(self.pkg_name, deviceName)
 
@@ -142,7 +141,7 @@ class WaveshareTriColorDisplay(VirtualEPD):
                       "epd7in5b_V2", "epd7in5bc"]
 
         try:
-            from waveshare_epd import epdconfig
+            from waveshare_epd import epdconfig  # noqa: F401
 
             result = [f"{WaveshareTriColorDisplay.pkg_name}.{n}" for n in deviceList]
         except ModuleNotFoundError:
@@ -180,7 +179,7 @@ class Waveshare102inDisplay(VirtualEPD):
     pkg_name = 'waveshare_epd'
 
     def __init__(self, deviceName, config):
-        super(MockDisplay, self).__init__(deviceName, config)
+        super(Waveshare102inDisplay, self).__init__(deviceName, config)
 
         deviceObj = self.load_display_driver(self.pkg_name, deviceName)
 
@@ -196,7 +195,7 @@ class Waveshare102inDisplay(VirtualEPD):
         result = []
 
         try:
-            from waveshare_epd import epdconfig
+            from waveshare_epd import epdconfig  # noqa: F401
 
             result = [f"{Waveshare102inDisplay.pkg_name}.epd1in02"]
         except ModuleNotFoundError:
@@ -223,6 +222,7 @@ class Waveshare102inDisplay(VirtualEPD):
         epdconfig.module_init()
         epdconfig.module_exit()
 
+
 class Waveshare3in7Display(VirtualEPD):
     """
     This class is for the Waveshare 3.7in display only as it
@@ -233,7 +233,7 @@ class Waveshare3in7Display(VirtualEPD):
     pkg_name = 'waveshare_epd'
 
     def __init__(self, deviceName, config):
-        super(MockDisplay, self).__init__(deviceName, config)
+        super(Waveshare3in7Display, self).__init__(deviceName, config)
 
         deviceObj = self.load_display_driver(self.pkg_name, deviceName)
 
@@ -249,7 +249,7 @@ class Waveshare3in7Display(VirtualEPD):
         result = []
 
         try:
-            from waveshare_epd import epdconfig
+            from waveshare_epd import epdconfig  # noqa: F401
 
             result = [f"{Waveshare102inDisplay.pkg_name}.epd3in7"]
         except ModuleNotFoundError:

--- a/src/omni_epd/virtualepd.py
+++ b/src/omni_epd/virtualepd.py
@@ -41,7 +41,7 @@ class VirtualEPD:
     height = 0  # height of display
     _device = None  # concrete device class, initialize in __init__
     _config = None  # configuration options passed in via dict at runtime or .ini file
-    __device_name = ""  # name of this device
+    _device_name = ""  # name of this device
 
     def __init__(self, deviceName, config):
         self._config = config

--- a/src/omni_epd/virtualepd.py
+++ b/src/omni_epd/virtualepd.py
@@ -18,7 +18,9 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 """
 
+import sys
 import importlib
+import importlib.util
 import logging
 from PIL import Image, ImageEnhance
 from . conf import IMAGE_DISPLAY, IMAGE_ENHANCEMENTS
@@ -112,6 +114,17 @@ class VirtualEPD:
             exit(2)
 
         return driver
+
+    # helper method to check if a module is (or can be) installed
+    @staticmethod
+    def check_module_installed(moduleName):
+        result = False
+
+        # check if the module is already loaded, or can be loaded
+        if(moduleName in sys.modules or (importlib.util.find_spec(moduleName)) is not None):
+            result = True
+
+        return result
 
     # REQUIRED - a list of devices supported by this class, format is {pkgname.devicename}
     @staticmethod


### PR DESCRIPTION
This is an attempt to work around the inconsistances in the waveshare `EPD` class libraries by defining some ways of handling major differences. The main types are listed below: 

### Waveshare General
These are all the main b/w EPD devices that share a common naming in their methods. The only big difference is that a few classes require an arg to their `init()` method. These are handled by identifying at the time of loading. At this point all are set to _Full refresh_. 

### Waveshare Tri Color
These are all the devices that, due to multi color options, require 2 `Image` objects to be passed to the `display()` function. The solution to these, for now, is to simply pass the b/w image and a blank image for the second type. This could be extended in the future to allow 2 color images. 

### Waveshare 1.02 in Display
This one is kind of an oddity in that it's method calls are all different than any other display. Easier to just make it's own class to handle. 

### Waveshare 3.7in Display
This device has some different method calls as well due to the fact it can do b/w or 4 tone grayscale. For now just the b/w call is supported but could be extended for the full 4 tone grayscale option in the future. 