### PR TITLE
Test Utility Fixes

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = omni_epd
-version = 0.2.0
+version = 0.2.1beta1
 author = Rob Weber
 author_email = robweberjr@gmail.com
 description = An EPD class abstraction to simplify communications across multiple display types.

--- a/src/omni_epd/test_utility.py
+++ b/src/omni_epd/test_utility.py
@@ -21,7 +21,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 import argparse
 from . import displayfactory
 from . errors import EPDNotFoundError
-from PIL import Image, ImageDraw
+from PIL import Image, ImageColor, ImageDraw
 
 
 class EPDTestUtility:
@@ -55,7 +55,7 @@ class EPDTestUtility:
             rY = y + (height - rHeight)/2
 
             print(f"Drawing rectangle of width {rWidth} and height {rHeight}")
-            imgObj.rectangle((rX, rY, rWidth + rX, rHeight + rY), outline=(0, 0, 0), width=2)
+            imgObj.rectangle((rX, rY, rWidth + rX, rHeight + rY), outline=ImageColor.getrgb("black"), width=2)
 
             return self.__draw_rectangle(imgObj, rWidth, rHeight, rX, rY, percent-step, step)
         else:
@@ -76,7 +76,7 @@ class EPDTestUtility:
     def draw(self):
 
         # create a blank image
-        im = Image.new('RGB', (self.epd.width, self.epd.height), color=(255,255,255))
+        im = Image.new('RGB', (self.epd.width, self.epd.height), color=ImageColor.getrgb("white"))
         draw = ImageDraw.Draw(im)
 
         # draw a series of rectangles

--- a/src/omni_epd/test_utility.py
+++ b/src/omni_epd/test_utility.py
@@ -55,7 +55,7 @@ class EPDTestUtility:
             rY = y + (height - rHeight)/2
 
             print(f"Drawing rectangle of width {rWidth} and height {rHeight}")
-            imgObj.rectangle((rX, rY, rWidth + rX, rHeight + rY), width=2)
+            imgObj.rectangle((rX, rY, rWidth + rX, rHeight + rY), outline=(0, 0, 0), width=2)
 
             return self.__draw_rectangle(imgObj, rWidth, rHeight, rX, rY, percent-step, step)
         else:
@@ -76,7 +76,7 @@ class EPDTestUtility:
     def draw(self):
 
         # create a blank image
-        im = Image.new('1', (self.epd.width, self.epd.height), color=1)
+        im = Image.new('RGB', (self.epd.width, self.epd.height), color=(255,255,255))
         draw = ImageDraw.Draw(im)
 
         # draw a series of rectangles


### PR DESCRIPTION
The test utility didn't work consistently. It did white/black and black/white rectangles for different displays. This modifies the way the images are generated to explicitly use RGB values and let the display driver classes do the conversion to what their specific device can display. 