### PR TITLE
Simplify Object Inheritance

### DIFF
--- a/src/omni_epd/conf.py
+++ b/src/omni_epd/conf.py
@@ -18,6 +18,9 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 """
 
+import importlib.util
+import sys
+
 # config file name
 CONFIG_FILE = "omni-epd.ini"
 
@@ -25,3 +28,14 @@ CONFIG_FILE = "omni-epd.ini"
 EPD_CONFIG = "EPD"
 IMAGE_DISPLAY = "Display"
 IMAGE_ENHANCEMENTS = "Image Enhancements"
+
+
+# helper method to check if a module is (or can be) installed
+def check_module_installed(moduleName):
+    result = False
+
+    # check if the module is already loaded, or can be loaded
+    if(moduleName in sys.modules or (importlib.util.find_spec(moduleName)) is not None):
+        result = True
+
+    return result

--- a/src/omni_epd/displayfactory.py
+++ b/src/omni_epd/displayfactory.py
@@ -52,11 +52,25 @@ def __loadConfig(deviceName):
     return config
 
 
+def _get_subclasses(cName):
+    """
+    Can be used to recursively find classes that implement
+    a given class resursively (ie, subclass of a subclass)
+    """
+    result = []
+
+    for sub in cName.__subclasses__():
+        result.append(sub)
+        result.extend(_get_subclasses(sub))
+
+    return result
+
+
 def list_supported_displays(as_dict=False):
     result = []
 
-    # get a list of display classes extending VirtualDisplayDevice
-    displayClasses = [(cls.__module__, cls.__name__) for cls in VirtualEPD.__subclasses__()]
+    # get a list of display classes extending VirtualEPD
+    displayClasses = [(cls.__module__, cls.__name__) for cls in _get_subclasses(VirtualEPD)]
 
     for modName, className in displayClasses:
         # load the module the class belongs to

--- a/src/omni_epd/displayfactory.py
+++ b/src/omni_epd/displayfactory.py
@@ -26,7 +26,7 @@ from . errors import EPDNotFoundError, EPDConfigurationError
 from . conf import CONFIG_FILE, EPD_CONFIG
 from . virtualepd import VirtualEPD
 from . displays.mock_display import MockDisplay  # noqa: F401
-from . displays.waveshare_display import WaveshareDisplay, WaveshareTriColorDisplay, Waveshare102inDisplay, WaveshareGrayscaleDisplay, WaveshareMultiColorDisplay  # noqa: F401,E501
+from . displays.waveshare_display import WaveshareBWDisplay, WaveshareTriColorDisplay, Waveshare102inDisplay, WaveshareGrayscaleDisplay, WaveshareMultiColorDisplay  # noqa: F401,E501
 from . displays.inky_display import InkyDisplay, InkyImpressionDisplay  # noqa: F401
 
 

--- a/src/omni_epd/displayfactory.py
+++ b/src/omni_epd/displayfactory.py
@@ -26,7 +26,7 @@ from . errors import EPDNotFoundError, EPDConfigurationError
 from . conf import CONFIG_FILE, EPD_CONFIG
 from . virtualepd import VirtualEPD
 from . displays.mock_display import MockDisplay  # noqa: F401
-from . displays.waveshare_display import WaveshareBWDisplay, WaveshareTriColorDisplay, Waveshare102inDisplay, WaveshareGrayscaleDisplay, WaveshareMultiColorDisplay  # noqa: F401,E501
+from . displays.waveshare_display import WaveshareDisplay  # noqa: F401
 from . displays.inky_display import InkyDisplay, InkyImpressionDisplay  # noqa: F401
 
 

--- a/src/omni_epd/displayfactory.py
+++ b/src/omni_epd/displayfactory.py
@@ -52,7 +52,7 @@ def __loadConfig(deviceName):
     return config
 
 
-def _get_subclasses(cName):
+def __get_subclasses(cName):
     """
     Can be used to recursively find classes that implement
     a given class resursively (ie, subclass of a subclass)
@@ -61,7 +61,7 @@ def _get_subclasses(cName):
 
     for sub in cName.__subclasses__():
         result.append(sub)
-        result.extend(_get_subclasses(sub))
+        result.extend(__get_subclasses(sub))
 
     return result
 
@@ -70,7 +70,7 @@ def list_supported_displays(as_dict=False):
     result = []
 
     # get a list of display classes extending VirtualEPD
-    displayClasses = [(cls.__module__, cls.__name__) for cls in _get_subclasses(VirtualEPD)]
+    displayClasses = [(cls.__module__, cls.__name__) for cls in __get_subclasses(VirtualEPD)]
 
     for modName, className in displayClasses:
         # load the module the class belongs to

--- a/src/omni_epd/displays/inky_display.py
+++ b/src/omni_epd/displays/inky_display.py
@@ -22,6 +22,7 @@ from .. virtualepd import VirtualEPD
 
 INKY_PKG = "inky"
 
+
 class InkyDisplay(VirtualEPD):
     """
     This is an abstraction for Pimoroni Inky pHat and wHat devices

--- a/src/omni_epd/displays/inky_display.py
+++ b/src/omni_epd/displays/inky_display.py
@@ -19,6 +19,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """
 
 from .. virtualepd import VirtualEPD
+from .. conf import check_module_installed
 
 INKY_PKG = "inky"
 
@@ -74,7 +75,7 @@ class InkyDisplay(VirtualEPD):
                       "what_black", "what_red", "what_yellow"]
 
         # python libs for this might not be installed - that's ok, return nothing
-        if(InkyDisplay.check_module_installed('inky')):
+        if(check_module_installed(INKY_PKG)):
             # if passed return list of devices
             result = [f"{INKY_PKG}.{n}" for n in deviceList]
 
@@ -129,7 +130,7 @@ class InkyImpressionDisplay(VirtualEPD):
         result = []
 
         # python libs for this might not be installed - that's ok, return nothing
-        if(InkyImpressionDisplay.check_module_installed('inky')):
+        if(check_module_installed(INKY_PKG)):
             # if passed return list of devices
             result = [f"{INKY_PKG}.impression"]
 

--- a/src/omni_epd/displays/inky_display.py
+++ b/src/omni_epd/displays/inky_display.py
@@ -20,6 +20,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 from .. virtualepd import VirtualEPD
 
+INKY_PKG = "inky"
 
 class InkyDisplay(VirtualEPD):
     """
@@ -27,7 +28,7 @@ class InkyDisplay(VirtualEPD):
     https://github.com/pimoroni/inky
     """
 
-    pkg_name = 'inky'
+    pkg_name = INKY_PKG
     mode = "black"  # default mode is black
     modes_available = ("black")
 
@@ -74,7 +75,7 @@ class InkyDisplay(VirtualEPD):
         # python libs for this might not be installed - that's ok, return nothing
         if(InkyDisplay.check_module_installed('inky')):
             # if passed return list of devices
-            result = [f"{InkyDisplay.pkg_name}.{n}" for n in deviceList]
+            result = [f"{INKY_PKG}.{n}" for n in deviceList]
 
         return result
 
@@ -103,7 +104,7 @@ class InkyImpressionDisplay(VirtualEPD):
     https://github.com/pimoroni/inky
     """
 
-    pkg_name = 'inky'
+    pkg_name = INKY_PKG
     mode = 'color'  # this uses color by default
     max_colors = 8  # 7 + CLEAN (no color)
     modes_available = ('bw', 'color')
@@ -129,7 +130,7 @@ class InkyImpressionDisplay(VirtualEPD):
         # python libs for this might not be installed - that's ok, return nothing
         if(InkyImpressionDisplay.check_module_installed('inky')):
             # if passed return list of devices
-            result = [f"{InkyImpressionDisplay.pkg_name}.impression"]
+            result = [f"{INKY_PKG}.impression"]
 
         return result
 

--- a/src/omni_epd/displays/waveshare_display.py
+++ b/src/omni_epd/displays/waveshare_display.py
@@ -20,6 +20,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 from .. virtualepd import VirtualEPD
 
+WAVESHARE_PKG = "waveshare_epd"
 
 class WaveshareDisplay(VirtualEPD):
     """
@@ -27,7 +28,7 @@ class WaveshareDisplay(VirtualEPD):
     https://github.com/waveshare/e-Paper
     """
 
-    pkg_name = 'waveshare_epd'
+    pkg_name = WAVESHARE_PKG
 
     # devices that use alternate init methods
     lutInitList = ["epd2in9", "epd2in13", "epd1in54"]
@@ -72,7 +73,7 @@ class WaveshareDisplay(VirtualEPD):
             result = WaveshareDisplay.lutInitList + WaveshareDisplay.modeInitList + commonDeviceList
 
             # return a list of all submodules (device types)
-            result = [f"{WaveshareDisplay.pkg_name}.{n}" for n in result]
+            result = [f"{WAVESHARE_PKG}.{n}" for n in result]
 
         return result
 
@@ -106,7 +107,7 @@ class WaveshareTriColorDisplay(VirtualEPD):
     https://github.com/waveshare/e-Paper
     """
 
-    pkg_name = 'waveshare_epd'
+    pkg_name = WAVESHARE_PKG
     max_colors = 3
 
     # list of all devices - some drivers cover more than one device
@@ -160,7 +161,7 @@ class WaveshareTriColorDisplay(VirtualEPD):
 
         # python libs for this might not be installed - that's ok, return nothing
         if(WaveshareTriColorDisplay.check_module_installed('waveshare_epd')):
-            result = [f"{WaveshareTriColorDisplay.pkg_name}.{n}" for n in WaveshareTriColorDisplay.deviceMap]
+            result = [f"{WAVESHARE_PKG}.{n}" for n in WaveshareTriColorDisplay.deviceMap]
 
         return result
 
@@ -206,7 +207,7 @@ class WaveshareGrayscaleDisplay(VirtualEPD):
     https://github.com/waveshare/e-Paper/blob/master/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd4in2.py
     """
 
-    pkg_name = 'waveshare_epd'
+    pkg_name = WAVESHARE_PKG
     modes_available = ("bw", "gray4")
     max_colors = 4
 
@@ -229,7 +230,7 @@ class WaveshareGrayscaleDisplay(VirtualEPD):
         result = []
 
         if(WaveshareGrayscaleDisplay.check_module_installed('waveshare_epd')):
-            result = [f"{WaveshareGrayscaleDisplay.pkg_name}.{n}" for n in WaveshareGrayscaleDisplay.deviceList]
+            result = [f"{WAVESHARE_PKG}.{n}" for n in WaveshareGrayscaleDisplay.deviceList]
 
         return result
 
@@ -276,7 +277,7 @@ class Waveshare102inDisplay(VirtualEPD):
     https://github.com/waveshare/e-Paper/blob/master/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd1in02.py
     """
 
-    pkg_name = 'waveshare_epd'
+    pkg_name = WAVESHARE_PKG
 
     def __init__(self, deviceName, config):
         super().__init__(deviceName, config)
@@ -295,7 +296,7 @@ class Waveshare102inDisplay(VirtualEPD):
         result = []
 
         if(Waveshare102inDisplay.check_module_installed('waveshare_epd')):
-            result = [f"{Waveshare102inDisplay.pkg_name}.epd1in02"]
+            result = [f"{WAVESHARE_PKG}.epd1in02"]
 
         return result
 
@@ -324,7 +325,7 @@ class WaveshareMultiColorDisplay(VirtualEPD):
     https://github.com/waveshare/e-Paper/blob/master/RaspberryPi_JetsonNano/python/lib/waveshare_epd/.py
     """
 
-    pkg_name = 'waveshare_epd'
+    pkg_name = WAVESHARE_PKG
     max_colors = 7
     modes_available = ('bw', 'color')
 
@@ -347,7 +348,7 @@ class WaveshareMultiColorDisplay(VirtualEPD):
         result = []
 
         if(WaveshareMultiColorDisplay.check_module_installed('waveshare_epd')):
-            result = [f"{WaveshareMultiColorDisplay.pkg_name}.{n}" for n in WaveshareMultiColorDisplay.deviceList]
+            result = [f"{WAVESHARE_PKG}.{n}" for n in WaveshareMultiColorDisplay.deviceList]
 
         return result
 

--- a/src/omni_epd/displays/waveshare_display.py
+++ b/src/omni_epd/displays/waveshare_display.py
@@ -19,6 +19,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """
 
 from .. virtualepd import VirtualEPD
+from .. conf import check_module_installed
 
 WAVESHARE_PKG = "waveshare_epd"
 
@@ -70,7 +71,7 @@ class WaveshareBWDisplay(VirtualEPD):
                             "epd7in5", "epd7in5_HD", "epd7in5_V2"]
 
         # python libs for this might not be installed - that's ok, return nothing
-        if(WaveshareBWDisplay.check_module_installed('waveshare_epd')):
+        if(check_module_installed(WAVESHARE_PKG)):
             result = WaveshareBWDisplay.lutInitList + WaveshareBWDisplay.modeInitList + commonDeviceList
 
             # return a list of all submodules (device types)
@@ -161,7 +162,7 @@ class WaveshareTriColorDisplay(VirtualEPD):
         result = []
 
         # python libs for this might not be installed - that's ok, return nothing
-        if(WaveshareTriColorDisplay.check_module_installed('waveshare_epd')):
+        if(check_module_installed(WAVESHARE_PKG)):
             result = [f"{WAVESHARE_PKG}.{n}" for n in WaveshareTriColorDisplay.deviceMap]
 
         return result
@@ -230,7 +231,7 @@ class WaveshareGrayscaleDisplay(VirtualEPD):
     def get_supported_devices():
         result = []
 
-        if(WaveshareGrayscaleDisplay.check_module_installed('waveshare_epd')):
+        if(check_module_installed(WAVESHARE_PKG)):
             result = [f"{WAVESHARE_PKG}.{n}" for n in WaveshareGrayscaleDisplay.deviceList]
 
         return result
@@ -296,7 +297,7 @@ class Waveshare102inDisplay(VirtualEPD):
     def get_supported_devices():
         result = []
 
-        if(Waveshare102inDisplay.check_module_installed('waveshare_epd')):
+        if(check_module_installed(WAVESHARE_PKG)):
             result = [f"{WAVESHARE_PKG}.epd1in02"]
 
         return result
@@ -348,7 +349,7 @@ class WaveshareMultiColorDisplay(VirtualEPD):
     def get_supported_devices():
         result = []
 
-        if(WaveshareMultiColorDisplay.check_module_installed('waveshare_epd')):
+        if(check_module_installed(WAVESHARE_PKG)):
             result = [f"{WAVESHARE_PKG}.{n}" for n in WaveshareMultiColorDisplay.deviceList]
 
         return result

--- a/src/omni_epd/displays/waveshare_display.py
+++ b/src/omni_epd/displays/waveshare_display.py
@@ -22,6 +22,7 @@ from .. virtualepd import VirtualEPD
 
 WAVESHARE_PKG = "waveshare_epd"
 
+
 class WaveshareDisplay(VirtualEPD):
     """
     This is an abstraction for Waveshare EPD devices that are single color only

--- a/src/omni_epd/displays/waveshare_display.py
+++ b/src/omni_epd/displays/waveshare_display.py
@@ -23,7 +23,7 @@ from .. virtualepd import VirtualEPD
 WAVESHARE_PKG = "waveshare_epd"
 
 
-class WaveshareDisplay(VirtualEPD):
+class WaveshareBWDisplay(VirtualEPD):
     """
     This is an abstraction for Waveshare EPD devices that are single color only
     https://github.com/waveshare/e-Paper
@@ -70,8 +70,8 @@ class WaveshareDisplay(VirtualEPD):
                             "epd7in5", "epd7in5_HD", "epd7in5_V2"]
 
         # python libs for this might not be installed - that's ok, return nothing
-        if(WaveshareDisplay.check_module_installed('waveshare_epd')):
-            result = WaveshareDisplay.lutInitList + WaveshareDisplay.modeInitList + commonDeviceList
+        if(WaveshareBWDisplay.check_module_installed('waveshare_epd')):
+            result = WaveshareBWDisplay.lutInitList + WaveshareBWDisplay.modeInitList + commonDeviceList
 
             # return a list of all submodules (device types)
             result = [f"{WAVESHARE_PKG}.{n}" for n in result]

--- a/src/omni_epd/virtualepd.py
+++ b/src/omni_epd/virtualepd.py
@@ -18,10 +18,8 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 """
 
-import sys
 import json
 import importlib
-import importlib.util
 import logging
 from PIL import Image, ImageEnhance
 from . conf import EPD_CONFIG, IMAGE_DISPLAY, IMAGE_ENHANCEMENTS
@@ -185,17 +183,6 @@ class VirtualEPD:
     # returns package.device name
     def getName(self):
         return self.__str__()
-
-    # helper method to check if a module is (or can be) installed
-    @staticmethod
-    def check_module_installed(moduleName):
-        result = False
-
-        # check if the module is already loaded, or can be loaded
-        if(moduleName in sys.modules or (importlib.util.find_spec(moduleName)) is not None):
-            result = True
-
-        return result
 
     # REQUIRED - a list of devices supported by this class, format is {pkgname.devicename}
     @staticmethod


### PR DESCRIPTION
There is a lot of duplicate code in some of the display classes - especially for the waveshare objects. This doesn't add any additional functionality but just reorganizes the code base to try and get rid of some of the duplication. Main points: 

* set a variable for the package names and use that to reference the package when needed (Inky and Waveshare)
* create a parent WaveshareDisplay class that all other waveshare devices inherit. This class will load device objects and set some common functions that pretty much all devices use. These can be overridden in child classes where needed but generally don't need to be. 