### PR TITLE
Correct driver names

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Below is a list of displays currently implemented in the library. The Omni Devic
 |  | [7.5inch HD e-Paper HAT](https://www.waveshare.com/7.5inch-HD-e-Paper-HAT.htm) |waveshare_epd.epd7in5_HD | bw |
 |  | [7.5inch HD e-Paper HAT B](https://www.waveshare.com/7.5inch-HD-e-Paper-HAT-B.htm) |waveshare_epd.epd7in5b_HD | bw, red |
 |  | [7.5inch e-Paper HAT B](https://www.waveshare.com/7.5inch-HD-e-Paper-HAT-B.htm)| waveshare_epd.epd7in5b <br> waveshare_epd.epd7in5b_V2 | bw, red |
-|  | [7.5inch e-Paper HAT C](https://www.waveshare.com/7.5inch-e-Paper-HAT-C.htm) | waveshare_epd.epd7in5bc | bw, yellow |
+|  | [7.5inch e-Paper HAT C](https://www.waveshare.com/7.5inch-e-Paper-HAT-C.htm) | waveshare_epd.epd7in5c | bw, yellow |
 
 
 ### Display Driver Installation

--- a/src/omni_epd/displays/waveshare_display.py
+++ b/src/omni_epd/displays/waveshare_display.py
@@ -153,7 +153,7 @@ class WaveshareTriColorDisplay(WaveshareDisplay):
                  "epd2in9b": {"driver": "epd2in9bc", "modes": ("bw", "red")},
                  "epd2in9b_V3": {"driver": "epd2in9b_V3", "modes": ("bw", "red")},
                  "epd2in9c": {"driver": "epd2in9bc", "modes": ("bw", "yellow")},
-                 "epd4in2bc": {"driver": "epd4in2bc", "modes": ("bw", "red")},
+                 "epd4in2b": {"driver": "epd4in2bc", "modes": ("bw", "red")},
                  "epd4in2c": {"driver": "epd4in2bc", "modes": ("bw", "yellow")},
                  "epd4in2b_V2": {"driver": "epd4in2b_V2", "modes": ("bw", "red")},
                  "epd5in83b": {"driver": "epd5in83bc", "modes": ("bw", "red")},


### PR DESCRIPTION
A couple of the device names were inconsistent between readme.md and waveshare_display.py