### PR TITLE
Clear() Method Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 - added [SlowMovie](https://github.com/TomWhitwell/SlowMovie) to list of implmenting projects
 
+### Changed
+
+- modified several of the Waveshare devices to make sure `init()`, `display()`, and `clear()` methods are all being called correctly based on device specifics
+
 ## Version 0.2.1
 
 ### Changed

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = omni_epd
-version = 0.2.2beta1
+version = 0.2.2beta2
 author = Rob Weber
 author_email = robweberjr@gmail.com
 description = An EPD class abstraction to simplify communications across multiple display types.

--- a/src/omni_epd/displays/waveshare_display.py
+++ b/src/omni_epd/displays/waveshare_display.py
@@ -85,7 +85,7 @@ class WaveshareBWDisplay(WaveshareDisplay):
                  "epd1in54_V2": {"alt_init": False, "lut_init": False, "alt_clear": True},
                  "epd2in9": {"alt_init": True, "lut_init": True, "alt_clear": True},
                  "epd2in9_V2": {"alt_init": False, "lut_init": False, "alt_clear": True},
-                 "epd2in9d": {"alt_init": False, "lut_init": False, "alt_clear": False},
+                 "epd2in9d": {"alt_init": False, "lut_init": False, "alt_clear": True},
                  "epd2in13": {"alt_init": True, "lut_init": True, "alt_clear": True},
                  "epd2in13_V2": {"alt_init": True, "lut_init": False, "alt_clear": False},
                  "epd2in13d": {"alt_init": False, "lut_init": False, "alt_clear": True},

--- a/src/omni_epd/displays/waveshare_display.py
+++ b/src/omni_epd/displays/waveshare_display.py
@@ -227,7 +227,7 @@ class WaveshareGrayscaleDisplay(WaveshareDisplay):
     modes_available = ("bw", "gray4")
     max_colors = 4
 
-    deviceMap = {"epd2in7": {"alt_clear": True},
+    deviceMap = {"epd2in7": {"alt_clear": False},
                  "epd3in7": {"alt_clear": True},
                  "epd4in2": {"alt_clear": False}}  # devices that support 4 shade grayscale
 

--- a/src/omni_epd/displays/waveshare_display.py
+++ b/src/omni_epd/displays/waveshare_display.py
@@ -84,7 +84,7 @@ class WaveshareBWDisplay(WaveshareDisplay):
     deviceMap = {"epd1in54": {"alt_init": True, "lut_init": True, "alt_clear": True},
                  "epd1in54_V2": {"alt_init": False, "lut_init": False, "alt_clear": True},
                  "epd2in9": {"alt_init": True, "lut_init": True, "alt_clear": True},
-                 "epd2in9_V2": {"alt_init": False, "lut_init": False, "alt_clear": False},
+                 "epd2in9_V2": {"alt_init": False, "lut_init": False, "alt_clear": True},
                  "epd2in9d": {"alt_init": False, "lut_init": False, "alt_clear": False},
                  "epd2in13": {"alt_init": True, "lut_init": True, "alt_clear": True},
                  "epd2in13_V2": {"alt_init": True, "lut_init": False, "alt_clear": False},

--- a/src/omni_epd/displays/waveshare_display.py
+++ b/src/omni_epd/displays/waveshare_display.py
@@ -130,6 +130,14 @@ class WaveshareBWDisplay(WaveshareDisplay):
         # no need to adjust palette, done in waveshare driver
         self._device.display(self._device.getbuffer(image))
 
+    def clear(self):
+        if(self._device_name in self.lutInitList):
+            # these devices need a color parameter
+            self._device.Clear(0xFF)  # hardcode white here
+        else:
+            # use standard clear method
+            super().clear()
+
 
 class WaveshareTriColorDisplay(WaveshareDisplay):
     """

--- a/src/omni_epd/displays/waveshare_display.py
+++ b/src/omni_epd/displays/waveshare_display.py
@@ -227,7 +227,9 @@ class WaveshareGrayscaleDisplay(WaveshareDisplay):
     modes_available = ("bw", "gray4")
     max_colors = 4
 
-    deviceList = ["epd2in7", "epd3in7", "epd4in2"]  # devices that support 4 shade grayscale
+    deviceMap = {"epd2in7": {"alt_clear": True},
+                 "epd3in7": {"alt_clear": True},
+                 "epd4in2": {"alt_clear": False}}  # devices that support 4 shade grayscale
 
     def __init__(self, deviceName, config):
         super().__init__(deviceName, config)
@@ -239,7 +241,7 @@ class WaveshareGrayscaleDisplay(WaveshareDisplay):
         result = []
 
         if(check_module_installed(WAVESHARE_PKG)):
-            result = [f"{WAVESHARE_PKG}.{n}" for n in WaveshareGrayscaleDisplay.deviceList]
+            result = [f"{WAVESHARE_PKG}.{n}" for n in WaveshareGrayscaleDisplay.deviceMap]
 
         return result
 
@@ -267,6 +269,17 @@ class WaveshareGrayscaleDisplay(WaveshareDisplay):
                 self._device.display_1Gray(self._device.getbuffer(image))
             else:
                 self._device.display(self._device.getbuffer(image))
+
+    def clear(self):
+        if(self.deviceMap[self._device_name]['alt_clear']):
+            # 3.7 in needs mode and color to clear
+            if(self._device_name == "epd3in7"):
+                mode = 0 if self.mode == "gray4" else 1
+                self._device.Clear(0xFF, mode)
+            else:
+                self._device.Clear(0xFF)  # use white for clear
+        else:
+            self._device.Clear()
 
 
 class Waveshare102inDisplay(WaveshareDisplay):

--- a/src/omni_epd/displays/waveshare_display.py
+++ b/src/omni_epd/displays/waveshare_display.py
@@ -88,7 +88,7 @@ class WaveshareBWDisplay(WaveshareDisplay):
                  "epd2in9d": {"alt_init": False, "lut_init": False, "alt_clear": False},
                  "epd2in13": {"alt_init": True, "lut_init": True, "alt_clear": True},
                  "epd2in13_V2": {"alt_init": True, "lut_init": False, "alt_clear": False},
-                 "epd2in13d": {"alt_init": False, "lut_init": False, "alt_clear": False},
+                 "epd2in13d": {"alt_init": False, "lut_init": False, "alt_clear": True},
                  "epd2in66": {"alt_init": True, "lut_init": False, "alt_clear": False},
                  "epd5in83": {"alt_init": False, "lut_init": False, "alt_clear": False},
                  "epd5in83_V2": {"alt_init": False, "lut_init": False, "alt_clear": False},

--- a/src/omni_epd/displays/waveshare_display.py
+++ b/src/omni_epd/displays/waveshare_display.py
@@ -82,7 +82,7 @@ class WaveshareBWDisplay(WaveshareDisplay):
 
     # devices that use alternate init methods
     deviceMap = {"epd1in54": {"alt_init": True, "lut_init": True, "alt_clear": True},
-                 "epd1in54_V2": {"alt_init": False, "lut_init": False, "alt_clear": False},
+                 "epd1in54_V2": {"alt_init": False, "lut_init": False, "alt_clear": True},
                  "epd2in9": {"alt_init": True, "lut_init": True, "alt_clear": True},
                  "epd2in9_V2": {"alt_init": False, "lut_init": False, "alt_clear": False},
                  "epd2in9d": {"alt_init": False, "lut_init": False, "alt_clear": False},

--- a/src/omni_epd/displays/waveshare_display.py
+++ b/src/omni_epd/displays/waveshare_display.py
@@ -81,10 +81,21 @@ class WaveshareBWDisplay(WaveshareDisplay):
     """
 
     # devices that use alternate init methods
-    lutInitList = ["epd2in9", "epd2in13", "epd1in54"]
-    modeInitList = ["epd2in66", "epd2in13_V2"]
+    deviceMap = {"epd1in54": {"alt_init": True, "lut_init": True, "alt_clear": True},
+                 "epd1in54_V2": {"alt_init": False, "lut_init": False, "alt_clear": False},
+                 "epd2in9": {"alt_init": True, "lut_init": True, "alt_clear": True},
+                 "epd2in9_V2": {"alt_init": False, "lut_init": False, "alt_clear": False},
+                 "epd2in9d": {"alt_init": False, "lut_init": False, "alt_clear": False},
+                 "epd2in13": {"alt_init": True, "lut_init": True, "alt_clear": True},
+                 "epd2in13_V2": {"alt_init": True, "lut_init": False, "alt_clear": False},
+                 "epd2in13d": {"alt_init": False, "lut_init": False, "alt_clear": False},
+                 "epd2in66": {"alt_init": True, "lut_init": False, "alt_clear": False},
+                 "epd5in83": {"alt_init": False, "lut_init": False, "alt_clear": False},
+                 "epd5in83_V2": {"alt_init": False, "lut_init": False, "alt_clear": False},
+                 "epd7in5": {"alt_init": False, "lut_init": False, "alt_clear": False},
+                 "epd7in5_HD": {"alt_init": False, "lut_init": False, "alt_clear": False},
+                 "epd7in5_V2": {"alt_init": False, "lut_init": False, "alt_clear": False}}
 
-    alt_init = False  # specify that init with a param should be used
     alt_init_param = 0  # the parameter to pass to init - specifies update mode (full vs partial)
 
     def __init__(self, deviceName, config):
@@ -92,36 +103,24 @@ class WaveshareBWDisplay(WaveshareDisplay):
 
         # device object loaded in parent class
 
-        # check if alternate init method is used
-        if(deviceName in self.lutInitList or deviceName in self.modeInitList):
-            self.alt_init = True
-
-            # some devices set the full instruction as the param
-            if(deviceName in self.lutInitList):
-                self.alt_init_param = self._device.lut_full_update
+        # some devices set the full instruction as the param
+        if(self.deviceMap[deviceName]['lut_init']):
+            self.alt_init_param = self._device.lut_full_update
 
     @staticmethod
     def get_supported_devices():
         result = []
 
-        # list of common devices that share init() and display() method calls
-        commonDeviceList = ["epd1in54_V2", "epd2in13d",
-                            "epd2in9_V2", "epd2in9d",
-                            "epd5in83", "epd5in83_V2",
-                            "epd7in5", "epd7in5_HD", "epd7in5_V2"]
-
         # python libs for this might not be installed - that's ok, return nothing
         if(check_module_installed(WAVESHARE_PKG)):
-            result = WaveshareBWDisplay.lutInitList + WaveshareBWDisplay.modeInitList + commonDeviceList
-
             # return a list of all submodules (device types)
-            result = [f"{WAVESHARE_PKG}.{n}" for n in result]
+            result = [f"{WAVESHARE_PKG}.{n}" for n in WaveshareBWDisplay.deviceMap]
 
         return result
 
     def prepare(self):
         # if device needs an init param
-        if(self.alt_init):
+        if(self.deviceMap[self._device_name]['alt_init']):
             self._device.init(self.alt_init_param)
         else:
             self._device.init()
@@ -131,12 +130,11 @@ class WaveshareBWDisplay(WaveshareDisplay):
         self._device.display(self._device.getbuffer(image))
 
     def clear(self):
-        if(self._device_name in self.lutInitList):
-            # these devices need a color parameter
-            self._device.Clear(0xFF)  # hardcode white here
+        if(self.deviceMap[self._device_name]['alt_clear']):
+            # device needs color parameter, hardcode white
+            self._device.Clear(0xFF)
         else:
-            # use standard clear method
-            super().clear()
+            self._device.Clear()
 
 
 class WaveshareTriColorDisplay(WaveshareDisplay):


### PR DESCRIPTION
Some devices require a color to be passed to the `Clear()` method in order for it to work. In the Waveshare examples this is typically white as that will make the screen appear "clear" for a two color display. This PR will add this additional parameter to devices that require it. 

__Changes__

The `WaveshareBWDisplay` class now uses a dict instead of an array to hold settings for each device type. The settings related to the different `init()` and `clear()` arguments were getting to complicated to keep in separate arrays. The dict makes it more clear what method calls correspond to which device. This could probably be further abstracted into the parent class but that's not necessary for now. 