### PR TITLE
Add dithering option

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,7 @@ install_requires =
   Pillow
   waveshare-epd @ git+https://github.com/waveshare/e-Paper.git#subdirectory=RaspberryPi_JetsonNano/python&egg=waveshare-epd
   inky[rpi,fonts]
+  hitherdither @ git+https://github.com/hbldh/hitherdither
 package_dir =
     = src
 packages = find:

--- a/src/omni_epd/virtualepd.py
+++ b/src/omni_epd/virtualepd.py
@@ -116,7 +116,6 @@ class VirtualEPD:
                 image = self._ditherImage(image, dither)
                 self._logger.debug(f"Applying dither: {dither}")
 
-
         return image
 
     """
@@ -180,7 +179,7 @@ class VirtualEPD:
 
     def _ditherImage(self, image, dither):
         if(self.mode == 'bw'):
-            palette=[255, 255, 255, 0, 0, 0]
+            palette = [255, 255, 255, 0, 0, 0]
         else:
             # load palette - this is a catch in case it was changed by the user
             colors = json.loads(self._get_device_option('palette_filter', json.dumps(self.palette_filter)))

--- a/src/omni_epd/virtualepd.py
+++ b/src/omni_epd/virtualepd.py
@@ -182,9 +182,12 @@ class VirtualEPD:
 
     def _ditherImage(self, image, palette=[255, 255, 255, 0, 0, 0]):
         # hitherdither expects a list of colors, i.e., [0xffffff, 0x000000, ...]
-        palette = [palette[i:i+3] for i in range(0, len(palette), 3)]
-        palette = hitherdither.palette.Palette([c[0] << 16 | c[1] << 8 | c[2] for c in palette])
-        thresholds = [64, 64, 64]
+        palette_hex = []
+        for i in range(0, len(palette), 3):
+            palette_hex += [(palette[i] << 16) + (palette[i + 1] << 8) + palette[i + 2]]
+        palette = hitherdither.palette.Palette(palette_hex)
+
+        thresholds = [128, 128, 128]
 
         if self.dither in ("atkinson", "jarvis-judice-ninke", "stucki", "burkes", "sierra3", "sierra2", "sierra-2-4a"):
             image = hitherdither.diffusion.error_diffusion_dithering(image, palette, method=self.dither, order=2)

--- a/src/omni_epd/virtualepd.py
+++ b/src/omni_epd/virtualepd.py
@@ -190,13 +190,13 @@ class VirtualEPD:
         thresholds = [128, 128, 128]
 
         if self.dither in ("atkinson", "jarvis-judice-ninke", "stucki", "burkes", "sierra3", "sierra2", "sierra-2-4a"):
-            image = hitherdither.diffusion.error_diffusion_dithering(image, palette, method=self.dither, order=2)
+            image = hitherdither.diffusion.error_diffusion_dithering(image, palette, method=self.dither)
         elif self.dither == "bayer":
-            image = hitherdither.ordered.bayer.bayer_dithering(image, palette, thresholds, order=8)
+            image = hitherdither.ordered.bayer.bayer_dithering(image, palette, thresholds)
         elif self.dither == "cluster-dot":
-            image = hitherdither.ordered.cluster.cluster_dot_dithering(image, palette, thresholds, order=8)
+            image = hitherdither.ordered.cluster.cluster_dot_dithering(image, palette, thresholds)
         elif self.dither == "yliluoma":
-            image = hitherdither.ordered.yliluoma.yliluomas_1_ordered_dithering(image, palette, order=8)
+            image = hitherdither.ordered.yliluoma.yliluomas_1_ordered_dithering(image, palette)
 
         return image
 

--- a/src/omni_epd/virtualepd.py
+++ b/src/omni_epd/virtualepd.py
@@ -152,7 +152,7 @@ class VirtualEPD:
     """
     Converts image to b/w or attempts a palette filter based on allowed colors in the display
     """
-    def _filterImage(self, image, dither=None):
+    def _filterImage(self, image, dither=Image.FLOYDSTEINBERG):
         if(self.mode == 'bw'):
             image = image.convert("1", dither=dither)
         else:
@@ -202,7 +202,7 @@ class VirtualEPD:
         elif dither == "yliluoma":
             image = hitherdither.ordered.yliluoma.yliluomas_1_ordered_dithering(image, palette)
         elif dither == "floyd-steinberg":
-            image = self._filterImage(image, Image.FLOYDSTEINBERG)
+            image = self._filterImage(image)
         elif dither == "none":
             image = self._filterImage(image, Image.NONE)
 

--- a/src/omni_epd/virtualepd.py
+++ b/src/omni_epd/virtualepd.py
@@ -112,9 +112,8 @@ class VirtualEPD:
 
         if(self._config.has_option(IMAGE_DISPLAY, "dither")) and self._config.get(IMAGE_DISPLAY, "dither") in self.dither_modes:
             dither = self._config.get(IMAGE_DISPLAY, "dither")
-            if(dither != "floyd-steinberg"):
-                image = self._ditherImage(image, dither)
-                self._logger.debug(f"Applying dither: {dither}")
+            image = self._ditherImage(image, dither)
+            self._logger.debug(f"Applying dither: {dither}")
 
         return image
 
@@ -153,7 +152,7 @@ class VirtualEPD:
     """
     Converts image to b/w or attempts a palette filter based on allowed colors in the display
     """
-    def _filterImage(self, image, dither=Image.FLOYDSTEINBERG):
+    def _filterImage(self, image, dither=None):
         if(self.mode == 'bw'):
             image = image.convert("1", dither=dither)
         else:
@@ -202,7 +201,9 @@ class VirtualEPD:
             image = hitherdither.ordered.cluster.cluster_dot_dithering(image, palette, thresholds)
         elif dither == "yliluoma":
             image = hitherdither.ordered.yliluoma.yliluomas_1_ordered_dithering(image, palette)
-        elif(dither == "none"):
+        elif dither == "floyd-steinberg":
+            image = self._filterImage(image, Image.FLOYDSTEINBERG)
+        elif dither == "none":
             image = self._filterImage(image, Image.NONE)
 
         image = image.convert("RGB")

--- a/src/omni_epd/virtualepd.py
+++ b/src/omni_epd/virtualepd.py
@@ -191,16 +191,18 @@ class VirtualEPD:
 
         # split the palette into RGB sublists
         palette = hitherdither.palette.Palette([palette[x:x+3] for x in range(0, len(palette), 3)])
-        thresholds = [128, 128, 128]
+        
+        threshold = json.loads(self._config.get(IMAGE_DISPLAY, "threshold", fallback="[128, 128, 128]"))
+        order = self._config.getint(IMAGE_DISPLAY, "order", fallback=None)
 
         if dither in ("atkinson", "jarvis-judice-ninke", "stucki", "burkes", "sierra3", "sierra2", "sierra-2-4a"):
-            image = hitherdither.diffusion.error_diffusion_dithering(image, palette, method=dither)
+            image = hitherdither.diffusion.error_diffusion_dithering(image, palette, dither)
         elif dither == "bayer":
-            image = hitherdither.ordered.bayer.bayer_dithering(image, palette, thresholds)
+            image = hitherdither.ordered.bayer.bayer_dithering(image, palette, threshold, order or 8)
         elif dither == "cluster-dot":
-            image = hitherdither.ordered.cluster.cluster_dot_dithering(image, palette, thresholds)
+            image = hitherdither.ordered.cluster.cluster_dot_dithering(image, palette, threshold, order or 4)
         elif dither == "yliluoma":
-            image = hitherdither.ordered.yliluoma.yliluomas_1_ordered_dithering(image, palette)
+            image = hitherdither.ordered.yliluoma.yliluomas_1_ordered_dithering(image, palette, order or 8)
         elif dither == "floyd-steinberg":
             image = self._filterImage(image)
         elif dither == "none":

--- a/src/omni_epd/virtualepd.py
+++ b/src/omni_epd/virtualepd.py
@@ -50,7 +50,8 @@ class VirtualEPD:
     palette_filter = [[255, 255, 255], [0, 0, 0]]  # assume only b+w supported by default, set in __init__
 
     dither = "floyd-steinberg"
-    dither_modes = ("floyd-steinberg", "atkinson", "jarvis-judice-ninke", "stucki", "burkes", "sierra3", "sierra2", "sierra-2-4a", "bayer", "cluster-dot", "yliluoma")
+    dither_modes = ("floyd-steinberg", "atkinson", "jarvis-judice-ninke", "stucki", "burkes",
+                    "sierra3", "sierra2", "sierra-2-4a", "bayer", "cluster-dot", "yliluoma")
 
     _device = None  # concrete device class, initialize in __init__
     _config = None  # configuration options passed in via dict at runtime or .ini file

--- a/src/omni_epd/virtualepd.py
+++ b/src/omni_epd/virtualepd.py
@@ -191,7 +191,7 @@ class VirtualEPD:
 
         # split the palette into RGB sublists
         palette = hitherdither.palette.Palette([palette[x:x+3] for x in range(0, len(palette), 3)])
-        
+
         threshold = json.loads(self._config.get(IMAGE_DISPLAY, "threshold", fallback="[128, 128, 128]"))
         order = self._config.getint(IMAGE_DISPLAY, "order", fallback=None)
 

--- a/src/omni_epd/virtualepd.py
+++ b/src/omni_epd/virtualepd.py
@@ -181,7 +181,7 @@ class VirtualEPD:
         return image
 
     def _ditherImage(self, image, palette=[255, 255, 255, 0, 0, 0]):
-        # hitherdither expects a list of colors, i.e., [0xffffff, 0x000000, ...] 
+        # hitherdither expects a list of colors, i.e., [0xffffff, 0x000000, ...]
         palette = [palette[i:i+3] for i in range(0, len(palette), 3)]
         palette = hitherdither.palette.Palette([c[0] << 16 | c[1] << 8 | c[2] for c in palette])
         thresholds = [64, 64, 64]


### PR DESCRIPTION
Per https://github.com/TomWhitwell/SlowMovie/issues/75, this adds every dithering algorithm available in [hitherdither](https://github.com/hbldh/hitherdither).

```ini
[EPD]
type=omni_epd.mock

[Display]
dither=bayer
order=8
threshold=[128, 128, 128]
```

Valid options for `dither`:
* `floyd-steinberg` (usually the default)
* `jarvis-judice-ninke`
* `stucki`
* `burkes`
* `sierra3`
* `sierra2`
* `sierra-2-4a`
* `atkinson`
* `bayer`
* `cluster-dot`
* `yliluoma`
* `none`

`floyd-steinberg` and `none` call `_filterimage()`, passing the dithering mode to Pillow. The rest use hitherdither.

Hitherdither is written completely in python, so some of these can be really slow. Bayer and cluster dot are fast, but the rest can take anywhere from several seconds to several minutes, depending on resolution and colors (tested on a Raspberry Pi 4.)

Bayer, cluster-dot, and yliluoma can be fine-tuned with the `order` and `threshold` options.
* `threshold` defines the color snap threshold. Takes an RGB list, default is `[128, 128, 128]`
* For bayer and yliluoma, `order` defines matrix size. Must be a power of 2, default is 8.
* For cluster-dot, `order` defines dot size. Can be 4 (small dots, default) or 8 (large dots).

Hitherdither actually accepts an order paremeter for the rest as well. It does _something_, but I'm not really sure what, so I've left it out for now.