### PR TITLE
Fix epd5in83c in WaveshareTriColorDisplay

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Below is a list of displays currently implemented in the library. The Omni Devic
 |  | [5.65inch e-Paper Module F](https://www.waveshare.com/5.65inch-e-Paper-Module-F.htm) |waveshare_epd.epd5in65f | bw, color |
 |  | [5.83inch e-Paper HAT](https://www.waveshare.com/5.83inch-e-Paper-HAT.htm) |waveshare_epd.epd5in83 <br> waveshare_epd.epd5in83_V2 | bw |
 |  | [5.83inch e-Paper HAT B](https://www.waveshare.com/5.83inch-e-Paper-HAT-B.htm) |waveshare_epd.epd5in83b <br> waveshare_epd.epd5in83b_V2 | bw, red |
-|  | [5.83inch e-Paper HAT C](https://www.waveshare.com/5.83inch-e-Paper-HAT-C.htm) |waveshare_epd.epd5in83c | bw, yellow |
+|  | [5.83inch e-Paper HAT C](https://www.waveshare.com/5.83inch-e-Paper-HAT-C.htm) | __waveshare_epd.epd5in83c__ | bw, yellow |
 |  | [7.5inch e-Paper HAT](https://www.waveshare.com/7.5inch-e-Paper-HAT.htm) |waveshare_epd.epd7in5 <br> __waveshare_epd.epd7in5_V2__ | bw |
 |  | [7.5inch HD e-Paper HAT](https://www.waveshare.com/7.5inch-HD-e-Paper-HAT.htm) |waveshare_epd.epd7in5_HD | bw |
 |  | [7.5inch HD e-Paper HAT B](https://www.waveshare.com/7.5inch-HD-e-Paper-HAT-B.htm) |waveshare_epd.epd7in5b_HD | bw, red |

--- a/README.md
+++ b/README.md
@@ -143,9 +143,9 @@ Below is a list of displays currently implemented in the library. The Omni Devic
 |  | [2.13inch e-Paper HAT D](https://www.waveshare.com/2.13inch-e-Paper-HAT-D.htm) | waveshare_epd.epd2in13d | bw |
 |  | [2.66inch e-Paper Module](https://www.waveshare.com/2.66inch-e-Paper-Module.htm) | waveshare_epd.epd2in66 | bw |
 |  | [2.66inch e-Paper Module B](https://www.waveshare.com/2.66inch-e-Paper-Module-B.htm) | waveshare_epd.epd2in66b | bw, red |
-|  | [2.7inch e-Paper HAT](https://www.waveshare.com/2.7inch-e-Paper-HAT.htm) | waveshare_epd.epd2in7 | bw |
+|  | [2.7inch e-Paper HAT](https://www.waveshare.com/2.7inch-e-Paper-HAT.htm) | __waveshare_epd.epd2in7__ | bw |
 |  | [2.7inch e-Paper HAT B](https://www.waveshare.com/2.7inch-e-Paper-HAT-B.htm) | waveshare_epd.epd2in7b <br> waveshare_epd.epd2in7b_V2 | bw, red |
-|  | [2.9inch e-Paper Module](https://www.waveshare.com/2.9inch-e-Paper-Module.htm) | waveshare_epd.epd2in9 <br> waveshare_epd.epd2in9_V2 | bw, red |
+|  | [2.9inch e-Paper Module](https://www.waveshare.com/2.9inch-e-Paper-Module.htm) | __waveshare_epd.epd2in9__ <br> waveshare_epd.epd2in9_V2 | bw |
 |  | [2.9inch e-Paper Module B](https://www.waveshare.com/2.9inch-e-Paper-Module-B.htm) | waveshare_epd.epd2in9b <br> waveshare_epd.epd2in9b_V3 | bw, red |
 |  | [2.9inch e-Paper Module C](https://www.waveshare.com/2.9inch-e-Paper-Module-C.htm) | waveshare_epd.epd2in9c | bw, yellow |
 |  | [2.9inch e-Paper HAT D](https://www.waveshare.com/2.9inch-e-Paper-HAT-D.htm) | waveshare_epd.epd2in9d | bw |

--- a/src/omni_epd/displays/waveshare_display.py
+++ b/src/omni_epd/displays/waveshare_display.py
@@ -171,7 +171,8 @@ class WaveshareTriColorDisplay(WaveshareDisplay):
                  "epd7in5b_HD": {"driver": "epd7in5b_HD", "modes": ("bw", "red")}}
 
     def __init__(self, deviceName, config):
-        super().__init__(deviceName, config)
+        driverName = self.deviceMap[deviceName]['driver']
+        super().__init__(driverName, config)
 
         # device object loaded in parent class
 

--- a/src/omni_epd/displays/waveshare_display.py
+++ b/src/omni_epd/displays/waveshare_display.py
@@ -201,17 +201,17 @@ class WaveshareTriColorDisplay(WaveshareDisplay):
 
         if(self.mode == 'bw'):
             # send the black/white image and blank second image (safer since some drivers require data)
-            self._device.display(self._device.getbuffer(image), [0x00] * (int(self.width/8) * self.height))
+            self._device.display(self._device.getbuffer(image), [255] * (int(self.width/8) * self.height))
         else:
             # apply the color filter to get a 3 color image
             image = self._filterImage(image)
 
             # separate out black from the other color
             img_black = image.copy()
-            img_black.putpalette((255, 255, 255, 0, 0, 0, 255, 255, 255) + (0, 0, 0)*253)
+            img_black.putpalette((255, 255, 255, 0, 0, 0, 255, 255, 255) + (255, 255, 255)*253)
 
             img_color = image.copy()
-            img_color.putpalette((255, 255, 255, 255, 255, 255, 0, 0, 0) + (0, 0, 0)*253)
+            img_color.putpalette((255, 255, 255, 255, 255, 255, 0, 0, 0) + (255, 255, 255)*253)
 
             self._device.display(self._device.getbuffer(img_black), self._device.getbuffer(img_color))
 


### PR DESCRIPTION
Use driver name instead of device name in `super().__init__()`