### PR TITLE
Remove inky fonts

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,7 @@ classifiers =
 install_requires =
   Pillow
   waveshare-epd @ git+https://github.com/waveshare/e-Paper.git#subdirectory=RaspberryPi_JetsonNano/python&egg=waveshare-epd
-  inky[rpi,fonts]
+  inky[rpi]
   hitherdither @ git+https://github.com/hbldh/hitherdither
 package_dir =
     = src


### PR DESCRIPTION
They're only needed for pimoroni's example scripts, which have other dependencies that aren't being installed, so they won't work by default anyway.