### PR TITLE
pin pillow and inky deps

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -17,9 +17,9 @@ classifiers =
 
 [options]
 install_requires =
-  Pillow
+  Pillow>=5.4.2
   waveshare-epd @ git+https://github.com/waveshare/e-Paper.git#subdirectory=RaspberryPi_JetsonNano/python&egg=waveshare-epd
-  inky[rpi]
+  inky[rpi]>=1.3.1
   hitherdither @ git+https://github.com/hbldh/hitherdither
 package_dir =
     = src


### PR DESCRIPTION
I had an older version of pillow installed which was preventing the test app from running. I've pinned the minimum pillow version to an old, but working version. also set the most recent inky version in this PR