### PR TITLE
Tri color fix

### DIFF
--- a/src/omni_epd/displays/waveshare_display.py
+++ b/src/omni_epd/displays/waveshare_display.py
@@ -208,14 +208,24 @@ class WaveshareTriColorDisplay(WaveshareDisplay):
         else:
             # apply the color filter to get a 3 color image
             image = self._filterImage(image)
-
-            # separate out black from the other color
+            
+            # convert to greyscale 
+            image = image.convert('L')
+            
+            # separate out black from the image
             img_black = image.copy()
-            img_black.putpalette((0, 0, 0, 255, 255, 255))
-
+            
+            # convert greys to black or white based on threshold (default value: 16)
+            img_black = img_black.point( lambda p: 255 if p > self.threshold else 0 )
+            
+            # separate out red from the image
             img_color = image.copy()
-            img_color.putpalette((255, 255, 255, 255, 255, 255, 0, 0, 0) + (255, 255, 255)*253)
-
+            
+            # convert greys to red (represented as black in the image) or white based on threshold (default value: 16)
+            img_color = img_color.point( lambda p: 0 if p > self.threshold and p < (255-self.threshold) else 255 )
+            # img_color = img_color.point( lambda p: 0 if p > 16 and p < 240 else 255 )
+            
+            # send to display
             self._device.display(self._device.getbuffer(img_black), self._device.getbuffer(img_color))
 
 

--- a/src/omni_epd/virtualepd.py
+++ b/src/omni_epd/virtualepd.py
@@ -43,6 +43,7 @@ class VirtualEPD:
     width = 0   # width of display
     height = 0  # height of display
     mode = "bw"  # mode of the display, bw by default, others defined by display class
+    threshold = 16  # greyscale threshold of bw selection for the display, default = 16, valid values from 0 (all white) to 255 (all black)
     modes_available = ("bw")  # modes this display supports, set in __init__
 
     # only used by displays that need palette filtering before sending to display driver
@@ -62,6 +63,7 @@ class VirtualEPD:
 
         # set the display mode
         self.mode = self._get_device_option('mode', self.mode)
+        self.threshold = int(self._get_device_option('threshold', self.threshold))
 
         self._logger = logging.getLogger(self.__str__())
 


### PR DESCRIPTION
Resolves #58 

Tested on the following screens:
- 7in5b_V2 - aaronr8684 
- 2in7b_V2 - donbing 

Could also be tested on:
- 2in7b - @txoof
- 5in83c  - @dr-boehmerie 
- 4in2c - aaronr8684 (pending delivery)

Potential issue:
@robweber Default value of '16' will work with yellow or red filters, but assigning a custom value higher will eliminate yellow and then red at an even higher value. Also at a value higher than 128, no color will be shown as it's currently written. We could hard code the `img_color` values for now (commented line 226) and come up with a better solution later, or put some additional logic or variable(s) to handle the color image logic separately (e.g. 'bandwidth' or similar). If you don't like the issue of no color with the variables, I think the best route is to use the hard coded line and add additional logic later to offer some customizability. 