### PR TITLE
Remove Image.copy()

### DIFF
--- a/src/omni_epd/displays/waveshare_display.py
+++ b/src/omni_epd/displays/waveshare_display.py
@@ -212,17 +212,11 @@ class WaveshareTriColorDisplay(WaveshareDisplay):
             # convert to greyscale
             image = image.convert('L')
 
-            # separate out black from the image
-            img_black = image.copy()
-
             # convert greys to black or white based on threshold (default value: 16)
-            img_black = img_black.point(lambda p: 255 if p >= 20 else 0)
-
-            # separate out red from the image
-            img_color = image.copy()
+            img_black = image.point(lambda p: 255 if p >= 20 else 0)
 
             # convert greys to red (represented as black in the image) or white based on threshold (default value: 16)
-            img_color = img_color.point(lambda p: 0 if 20 < p < 235 else 255)
+            img_color = image.point(lambda p: 0 if 20 < p < 235 else 255)
 
             # send to display
             self._device.display(self._device.getbuffer(img_black), self._device.getbuffer(img_color))


### PR DESCRIPTION
I just realized that it's no longer necessary to make copies of `image`. `Image.point()` returns a new image.