### PR TITLE
Pytest enhancements

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -16,9 +16,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip build
-          python -m build
-          pip install -r src/omni_epd.egg-info/requires.txt
+          pip install .[dev]
       - name: Test with pytest
         run: |
-          pip install pytest
           pytest

--- a/tests/all_options.ini
+++ b/tests/all_options.ini
@@ -1,0 +1,15 @@
+[EPD]
+type=omni_epd.mock
+mode=color
+
+[Display]
+rotate = 90
+flip_horizontal=True
+flip_vertical=True
+dither=cluster-dot
+order=4
+
+[Image Enhancements]
+contrast=2
+brightness=2
+sharpness=2

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -19,8 +19,9 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """
 import os.path
 
-GOOD_EPD_CONFIG = "omni_epd.mock"  # this should always be a valid EPD
-BAD_EPD_CONFIG = "omni_epd.bad"  # this is not a valid EPD
+GOOD_EPD_NAME = "omni_epd.mock"  # this should always be a valid EPD
+BAD_EPD_NAME = "omni_epd.bad"  # this is not a valid EPD
+
 BAD_CONFIG_FILE = 'bad_conf.ini'  # name of invalid configuration file
 ALL_IMAGE_OPTIONS = "all_options.ini"  # ini file that attempt to run all base options
 

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -17,8 +17,12 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 """
+import os.path
 
 GOOD_EPD_CONFIG = "omni_epd.mock"  # this should always be a valid EPD
 BAD_EPD_CONFIG = "omni_epd.bad"  # this is not a valid EPD
 BAD_CONFIG_FILE = 'bad_conf.ini'  # name of invalid configuration file
 ALL_IMAGE_OPTIONS = "all_options.ini"  # ini file that attempt to run all base options
+
+# Testing Images
+GALAXY_IMAGE = os.path.join(os.getcwd(), "examples", "PIA03519_small.jpg")

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -1,0 +1,24 @@
+"""
+Copyright 2022 Rob Weber
+
+This file is part of omni-epd
+
+omni-epd is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""
+
+GOOD_EPD_CONFIG = "omni_epd.mock"  # this should always be a valid EPD
+BAD_EPD_CONFIG = "omni_epd.bad"  # this is not a valid EPD
+BAD_CONFIG_FILE = 'bad_conf.ini'  # name of invalid configuration file
+ALL_IMAGE_OPTIONS = "all_options.ini"  # ini file that attempt to run all base options

--- a/tests/test_epd_loading.py
+++ b/tests/test_epd_loading.py
@@ -43,13 +43,13 @@ class TestEpdLoading(unittest.TestCase):
         """
         Confirm error thrown if an invalid name passed to load function
         """
-        self.assertRaises(EPDNotFoundError, displayfactory.load_display_driver, constants.BAD_EPD_CONFIG)
+        self.assertRaises(EPDNotFoundError, displayfactory.load_display_driver, constants.BAD_EPD_NAME)
 
     def test_loading_success(self):
         """
         Confirm a good display can be loaded and extends VirtualEPD
         """
-        epd = displayfactory.load_display_driver(constants.GOOD_EPD_CONFIG)
+        epd = displayfactory.load_display_driver(constants.GOOD_EPD_NAME)
 
         assert isinstance(epd, VirtualEPD)
 
@@ -63,7 +63,7 @@ class TestEpdLoading(unittest.TestCase):
         copyfile(os.path.join(os.getcwd(), "tests", CONFIG_FILE), os.path.join(os.getcwd(), CONFIG_FILE))
         time.sleep(1)
 
-        epd = displayfactory.load_display_driver(constants.GOOD_EPD_CONFIG)
+        epd = displayfactory.load_display_driver(constants.GOOD_EPD_NAME)
 
         assert epd._config.has_option(IMAGE_DISPLAY, 'rotate')
         assert epd._config.getfloat(IMAGE_DISPLAY, 'rotate') == 90
@@ -76,14 +76,14 @@ class TestEpdLoading(unittest.TestCase):
         Test that when both omni-epd.ini file is present and device specific INI present
         that the device specific config overrides options in global config
         """
-        deviceConfig = constants.GOOD_EPD_CONFIG + ".ini"
+        deviceConfig = constants.GOOD_EPD_NAME + ".ini"
 
         # set up a global config file and device config
         copyfile(os.path.join(os.getcwd(), "tests", CONFIG_FILE), os.path.join(os.getcwd(), CONFIG_FILE))
         copyfile(os.path.join(os.getcwd(), "tests", deviceConfig), os.path.join(os.getcwd(), deviceConfig))
         time.sleep(1)
 
-        epd = displayfactory.load_display_driver(constants.GOOD_EPD_CONFIG)
+        epd = displayfactory.load_display_driver(constants.GOOD_EPD_NAME)
 
         # device should override global
         assert epd._config.has_option(IMAGE_DISPLAY, 'flip_horizontal')
@@ -98,7 +98,7 @@ class TestEpdLoading(unittest.TestCase):
         Test that a device will load when given the type= option in the omni-epd.ini file
         and no args to load_display_driver()
         """
-        deviceConfig = constants.GOOD_EPD_CONFIG + ".ini"
+        deviceConfig = constants.GOOD_EPD_NAME + ".ini"
 
         # set up a global config file
         copyfile(os.path.join(os.getcwd(), "tests", CONFIG_FILE), os.path.join(os.getcwd(), CONFIG_FILE))
@@ -113,17 +113,17 @@ class TestEpdLoading(unittest.TestCase):
         self.assertFalse(epd._config.getboolean(IMAGE_DISPLAY, 'flip_horizontal'))
 
         # should attempt to load passed in driver, and fail, instead of one in conf file
-        self.assertRaises(EPDNotFoundError, displayfactory.load_display_driver, constants.BAD_EPD_CONFIG)
+        self.assertRaises(EPDNotFoundError, displayfactory.load_display_driver, constants.BAD_EPD_NAME)
 
     def test_configuration_error(self):
         """
         Confirm that an EPDConfigurationError is thrown by passing a bad mode value
         to a display
         """
-        deviceConfig = constants.GOOD_EPD_CONFIG + ".ini"
+        deviceConfig = constants.GOOD_EPD_NAME + ".ini"
 
         # copy bad config file to be loaded
         copyfile(os.path.join(os.getcwd(), "tests", constants.BAD_CONFIG_FILE), os.path.join(os.getcwd(), deviceConfig))
 
         # load the display driver, shoudl throw EPDConfigurationError
-        self.assertRaises(EPDConfigurationError, displayfactory.load_display_driver, constants.GOOD_EPD_CONFIG)
+        self.assertRaises(EPDConfigurationError, displayfactory.load_display_driver, constants.GOOD_EPD_NAME)

--- a/tests/test_epd_loading.py
+++ b/tests/test_epd_loading.py
@@ -12,7 +12,7 @@ from omni_epd.virtualepd import VirtualEPD
 from omni_epd.conf import IMAGE_DISPLAY, CONFIG_FILE
 
 
-class TestomniEpd(unittest.TestCase):
+class TestEpdLoading(unittest.TestCase):
 
     def _delete_ini(self):
         fileList = glob.glob(os.path.join(os.getcwd(), "*.ini"))

--- a/tests/test_image_processing.py
+++ b/tests/test_image_processing.py
@@ -1,16 +1,13 @@
 import unittest
 import os
 import time
-import json
 import glob
 import pytest
 from . import constants as constants
 from PIL import Image
 from shutil import copyfile
-from omni_epd import EPDNotFoundError, EPDConfigurationError
 from omni_epd import displayfactory
-from omni_epd.virtualepd import VirtualEPD
-from omni_epd.conf import IMAGE_DISPLAY, CONFIG_FILE
+from omni_epd.conf import CONFIG_FILE
 
 
 class TestImageProcessing(unittest.TestCase):

--- a/tests/test_image_processing.py
+++ b/tests/test_image_processing.py
@@ -1,0 +1,50 @@
+import unittest
+import os
+import time
+import json
+import glob
+import pytest
+from . import constants as constants
+from PIL import Image
+from shutil import copyfile
+from omni_epd import EPDNotFoundError, EPDConfigurationError
+from omni_epd import displayfactory
+from omni_epd.virtualepd import VirtualEPD
+from omni_epd.conf import IMAGE_DISPLAY, CONFIG_FILE
+
+
+class TestImageProcessing(unittest.TestCase):
+
+    def _delete_files(self, file_type='ini'):
+        fileList = glob.glob(os.path.join(os.getcwd(), "*." + file_type))
+
+        for f in fileList:
+            # don't bother catching errors - just let it fail out
+            os.remove(f)
+
+    @pytest.fixture(autouse=True)
+    def run_before_and_after_tests(self):
+        # clean up any files left over from previous tests
+        self._delete_files()
+        self._delete_files('.png')
+        yield
+
+        # clean up any files made during this test
+        self._delete_files()
+        self._delete_files('.png')
+
+    def test_image_processing_options(self):
+        """
+        Test all common image processing options (rotating, dithering, contrast, etc)
+        https://github.com/robweber/omni-epd#advanced-epd-control
+        """
+
+        copyfile(os.path.join(os.getcwd(), "tests", constants.ALL_IMAGE_OPTIONS), os.path.join(os.getcwd(), CONFIG_FILE))
+        time.sleep(1)
+
+        epd = displayfactory.load_display_driver(constants.GOOD_EPD_CONFIG)
+
+        # write the image
+        image = Image.open(constants.GALAXY_IMAGE)
+
+        epd.display(image)

--- a/tests/test_image_processing.py
+++ b/tests/test_image_processing.py
@@ -42,7 +42,7 @@ class TestImageProcessing(unittest.TestCase):
         copyfile(os.path.join(os.getcwd(), "tests", constants.ALL_IMAGE_OPTIONS), os.path.join(os.getcwd(), CONFIG_FILE))
         time.sleep(1)
 
-        epd = displayfactory.load_display_driver(constants.GOOD_EPD_CONFIG)
+        epd = displayfactory.load_display_driver(constants.GOOD_EPD_NAME)
 
         # write the image
         image = Image.open(constants.GALAXY_IMAGE)

--- a/tests/test_omni_epd.py
+++ b/tests/test_omni_epd.py
@@ -4,6 +4,7 @@ import time
 import json
 import glob
 import pytest
+from . import constants as constants
 from shutil import copyfile
 from omni_epd import EPDNotFoundError, EPDConfigurationError
 from omni_epd import displayfactory
@@ -12,9 +13,6 @@ from omni_epd.conf import IMAGE_DISPLAY, CONFIG_FILE
 
 
 class TestomniEpd(unittest.TestCase):
-    goodEpd = "omni_epd.mock"  # this should always be a valid EPD
-    badEpd = "omni_epd.bad"  # this is not a valid EPD
-    badConfig = 'bad_conf.ini'  # name of invalid configuration file
 
     def _delete_ini(self):
         fileList = glob.glob(os.path.join(os.getcwd(), "*.ini"))
@@ -45,13 +43,13 @@ class TestomniEpd(unittest.TestCase):
         """
         Confirm error thrown if an invalid name passed to load function
         """
-        self.assertRaises(EPDNotFoundError, displayfactory.load_display_driver, self.badEpd)
+        self.assertRaises(EPDNotFoundError, displayfactory.load_display_driver, constants.BAD_EPD_CONFIG)
 
     def test_loading_success(self):
         """
         Confirm a good display can be loaded and extends VirtualEPD
         """
-        epd = displayfactory.load_display_driver(self.goodEpd)
+        epd = displayfactory.load_display_driver(constants.GOOD_EPD_CONFIG)
 
         assert isinstance(epd, VirtualEPD)
 
@@ -65,7 +63,7 @@ class TestomniEpd(unittest.TestCase):
         copyfile(os.path.join(os.getcwd(), "tests", CONFIG_FILE), os.path.join(os.getcwd(), CONFIG_FILE))
         time.sleep(1)
 
-        epd = displayfactory.load_display_driver(self.goodEpd)
+        epd = displayfactory.load_display_driver(constants.GOOD_EPD_CONFIG)
 
         assert epd._config.has_option(IMAGE_DISPLAY, 'rotate')
         assert epd._config.getfloat(IMAGE_DISPLAY, 'rotate') == 90
@@ -78,14 +76,14 @@ class TestomniEpd(unittest.TestCase):
         Test that when both omni-epd.ini file is present and device specific INI present
         that the device specific config overrides options in global config
         """
-        deviceConfig = self.goodEpd + ".ini"
+        deviceConfig = constants.GOOD_EPD_CONFIG + ".ini"
 
         # set up a global config file and device config
         copyfile(os.path.join(os.getcwd(), "tests", CONFIG_FILE), os.path.join(os.getcwd(), CONFIG_FILE))
         copyfile(os.path.join(os.getcwd(), "tests", deviceConfig), os.path.join(os.getcwd(), deviceConfig))
         time.sleep(1)
 
-        epd = displayfactory.load_display_driver(self.goodEpd)
+        epd = displayfactory.load_display_driver(constants.GOOD_EPD_CONFIG)
 
         # device should override global
         assert epd._config.has_option(IMAGE_DISPLAY, 'flip_horizontal')
@@ -100,7 +98,7 @@ class TestomniEpd(unittest.TestCase):
         Test that a device will load when given the type= option in the omni-epd.ini file
         and no args to load_display_driver()
         """
-        deviceConfig = self.goodEpd + ".ini"
+        deviceConfig = constants.GOOD_EPD_CONFIG + ".ini"
 
         # set up a global config file
         copyfile(os.path.join(os.getcwd(), "tests", CONFIG_FILE), os.path.join(os.getcwd(), CONFIG_FILE))
@@ -115,17 +113,17 @@ class TestomniEpd(unittest.TestCase):
         self.assertFalse(epd._config.getboolean(IMAGE_DISPLAY, 'flip_horizontal'))
 
         # should attempt to load passed in driver, and fail, instead of one in conf file
-        self.assertRaises(EPDNotFoundError, displayfactory.load_display_driver, self.badEpd)
+        self.assertRaises(EPDNotFoundError, displayfactory.load_display_driver, constants.BAD_EPD_CONFIG)
 
     def test_configuration_error(self):
         """
         Confirm that an EPDConfigurationError is thrown by passing a bad mode value
         to a display
         """
-        deviceConfig = self.goodEpd + ".ini"
+        deviceConfig = constants.GOOD_EPD_CONFIG + ".ini"
 
         # copy bad config file to be loaded
-        copyfile(os.path.join(os.getcwd(), "tests", self.badConfig), os.path.join(os.getcwd(), deviceConfig))
+        copyfile(os.path.join(os.getcwd(), "tests", constants.BAD_CONFIG_FILE), os.path.join(os.getcwd(), deviceConfig))
 
         # load the display driver, shoudl throw EPDConfigurationError
-        self.assertRaises(EPDConfigurationError, displayfactory.load_display_driver, self.goodEpd)
+        self.assertRaises(EPDConfigurationError, displayfactory.load_display_driver, constants.GOOD_EPD_CONFIG)


### PR DESCRIPTION
Modifies the GitHub action to pull in dependencies from the `setup.cfg` file. 

Modifies the tests a bit so the naming conventions are better and adds a test for actually applying all available config options. There was an issue previously where one was failing due to a downstream library update, this will catch that they can at least be run without errors. It does not compare the images for veracity (ie, rotate actually rotates based on a known good image). That could be an potential addition later. 