### PR TITLE
Upgrading Pillow Version 9.1+

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = omni_epd
-version = 0.3.1
+version = 0.3.2~beta1
 author = Rob Weber
 author_email = robweberjr@gmail.com
 description = An EPD class abstraction to simplify communications across multiple display types.

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,7 @@ classifiers =
 
 [options]
 install_requires =
-  Pillow>=5.4.2
+  Pillow>=9.1.0
   waveshare-epd @ git+https://github.com/waveshare/e-Paper.git#subdirectory=RaspberryPi_JetsonNano/python&egg=waveshare-epd
   inky[rpi]>=1.3.1
   IT8951 @ git+https://github.com/GregDMeyer/IT8951

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,3 +43,4 @@ omni_epd = didder
 
 [flake8]
 max-line-length = 150
+ignore=E275

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = omni_epd
-version = 0.3.2~beta1
+version = 0.3.2~beta2
 author = Rob Weber
 author_email = robweberjr@gmail.com
 description = An EPD class abstraction to simplify communications across multiple display types.
@@ -43,4 +43,3 @@ omni_epd = didder
 
 [flake8]
 max-line-length = 150
-ignore=E275

--- a/src/omni_epd/displays/mock_display.py
+++ b/src/omni_epd/displays/mock_display.py
@@ -61,9 +61,9 @@ class MockDisplay(VirtualEPD):
         # 216 colors total
         result = []
         for i in range(0, 216):
-            row = int(i/6)
+            row = int(i / 6)
             # red = row/6, green=row%6, blue=current column
-            result.append([shades[int(row/6)], shades[int(row % 6)], shades[i - (row * 6)]])
+            result.append([shades[int(row / 6)], shades[int(row % 6)], shades[i - (row * 6)]])
 
         return result
 

--- a/src/omni_epd/test_utility.py
+++ b/src/omni_epd/test_utility.py
@@ -51,13 +51,13 @@ class EPDTestUtility:
             rHeight = height * percent
 
             # calculate the starting position to center it
-            rX = x + (width - rWidth)/2
-            rY = y + (height - rHeight)/2
+            rX = x + (width - rWidth) / 2
+            rY = y + (height - rHeight) / 2
 
             print(f"Drawing rectangle of width {rWidth} and height {rHeight}")
             imgObj.rectangle((rX, rY, rWidth + rX, rHeight + rY), outline=ImageColor.getrgb("black"), width=2)
 
-            return self.__draw_rectangle(imgObj, rWidth, rHeight, rX, rY, percent-step, step)
+            return self.__draw_rectangle(imgObj, rWidth, rHeight, rX, rY, percent - step, step)
         else:
             return imgObj
 

--- a/src/omni_epd/virtualepd.py
+++ b/src/omni_epd/virtualepd.py
@@ -172,7 +172,7 @@ class VirtualEPD:
             palette_image = Image.new("P", (1, 1))
 
             # set the palette, set all other colors to 0
-            palette_image.putpalette(palette + [0, 0, 0] * (256-len(colors)))
+            palette_image.putpalette(palette + [0, 0, 0] * (256 - len(colors)))
 
             if(image.mode != 'RGB'):
                 # convert to RGB as quantize requires it

--- a/src/omni_epd/virtualepd.py
+++ b/src/omni_epd/virtualepd.py
@@ -91,11 +91,11 @@ class VirtualEPD:
             self._logger.debug(f"Rotating image {self._config.getfloat(IMAGE_DISPLAY, 'rotate')}")
 
         if(self._config.has_option(IMAGE_DISPLAY, "flip_horizontal") and self._config.getboolean(IMAGE_DISPLAY, "flip_horizontal")):
-            image = image.transpose(method=Image.FLIP_LEFT_RIGHT)
+            image = image.transpose(method=Image.Transpose.FLIP_LEFT_RIGHT)
             self._logger.debug("Flipping image horizontally")
 
         if(self._config.has_option(IMAGE_DISPLAY, "flip_vertical") and self._config.getboolean(IMAGE_DISPLAY, "flip_vertical")):
-            image = image.transpose(method=Image.FLIP_TOP_BOTTOM)
+            image = image.transpose(method=Image.Transpose.FLIP_TOP_BOTTOM)
             self._logger.debug("Flipping image vertically")
 
         if(self._config.has_option(IMAGE_ENHANCEMENTS, "contrast")):
@@ -155,7 +155,7 @@ class VirtualEPD:
     """
     Converts image to b/w or attempts a palette filter based on allowed colors in the display
     """
-    def _filterImage(self, image, dither=Image.FLOYDSTEINBERG, force_palette=False):
+    def _filterImage(self, image, dither=Image.Dither.FLOYDSTEINBERG, force_palette=False):
         if(self.mode == 'bw' and not force_palette):
             image = image.convert("1", dither=dither)
         else:
@@ -215,7 +215,7 @@ class VirtualEPD:
         cmd += ["--strength", self._config.get(IMAGE_DISPLAY, 'dither_strength', raw=True, fallback='1.0')]
 
         if(dither == "none"):
-            return self._filterImage(image, Image.NONE)
+            return self._filterImage(image, Image.Dither.NONE)
         elif(dither in dither_modes_ordered):
             cmd += ["odm", dither]
         elif(dither in dither_modes_diffusion):


### PR DESCRIPTION
This changes the required Pillow version to 9.1 or greater and changes several Pillow static variables to use their updated counterparts. These variables were changed starting with Pillow 9.1 and the old ones removed in 10.0. 

The IT8951 library has already updated code to use the newer variable names so at minimum `omni-epd` needs Pillow to be at that version. This fixes #76 