### PR TITLE
Waveshare 4-color displays

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,12 +128,12 @@ Below is a list of displays currently implemented in the library. The Omni Devic
 |  | [1.54inch E-Ink display module](https://www.waveshare.com/1.54inch-e-Paper-Module.htm) | waveshare_epd.epdlin54 <br> waveshare_epd.epdlin54_V2 | bw |
 |  | [1.54inch e-Paper Module B](https://www.waveshare.com/1.54inch-e-Paper-Module-B.htm) | waveshare_epd.epdlin54b <br> waveshare_epd.epdlin54b_V2 | bw, red |
 |  | [1.54inch e-Paper Module C ](https://www.waveshare.com/1.54inch-e-Paper-Module-C.htm) | waveshare_epd.epdlin54c | bw, yellow |
-|  | [1.64inch e-Paper Module G ](https://www.waveshare.com/1.64inch-e-paper-module-g.htm) | waveshare_epd.epd1in64g | bw, color4 |
+|  | [1.64inch e-Paper Module G ](https://www.waveshare.com/1.64inch-e-paper-module-g.htm) | waveshare_epd.epd1in64g | bw, red, yellow, 4color |
 |  | [2.13inch e-Paper HAT](https://www.waveshare.com/2.13inch-e-Paper-HAT.htm) | waveshare_epd.epd2in13 <br>  waveshare_epd.epd2in13_V2 | bw |
 |  | [2.13inch e-Paper HAT B](https://www.waveshare.com/2.13inch-e-Paper-HAT-B.htm) | waveshare_epd.epd2in13b <br> waveshare_epd.epd2in13b_V3 | bw, red |
 |  | [2.13inch e-Paper HAT C ](https://www.waveshare.com/2.13inch-e-Paper-HAT-C.htm) | waveshare_epd.epd2in13c | bw, yellow |
 |  | [2.13inch e-Paper HAT D](https://www.waveshare.com/2.13inch-e-Paper-HAT-D.htm) | waveshare_epd.epd2in13d | bw |
-|  | 2.36inch e-Paper Module G | waveshare_epd.epd2in36g | bw, color4 |
+|  | 2.36inch e-Paper Module G | waveshare_epd.epd2in36g | bw, red, yellow, 4color |
 |  | [2.66inch e-Paper Module](https://www.waveshare.com/2.66inch-e-Paper-Module.htm) | waveshare_epd.epd2in66 | bw |
 |  | [2.66inch e-Paper Module B](https://www.waveshare.com/2.66inch-e-Paper-Module-B.htm) | waveshare_epd.epd2in66b | bw, red |
 |  | [2.7inch e-Paper HAT](https://www.waveshare.com/2.7inch-e-Paper-HAT.htm) | __waveshare_epd.epd2in7__ | bw |
@@ -142,19 +142,19 @@ Below is a list of displays currently implemented in the library. The Omni Devic
 |  | [2.9inch e-Paper Module B](https://www.waveshare.com/2.9inch-e-Paper-Module-B.htm) | waveshare_epd.epd2in9b <br> waveshare_epd.epd2in9b_V3 | bw, red |
 |  | [2.9inch e-Paper Module C](https://www.waveshare.com/2.9inch-e-Paper-Module-C.htm) | waveshare_epd.epd2in9c | bw, yellow |
 |  | [2.9inch e-Paper HAT D](https://www.waveshare.com/2.9inch-e-Paper-HAT-D.htm) | waveshare_epd.epd2in9d | bw |
-|  | [3inch e-Paper Module G](https://www.waveshare.com/3inch-e-paper-module-g.htm) | waveshare_epd.epd3in0g | bw, color4 |
+|  | [3inch e-Paper Module G](https://www.waveshare.com/3inch-e-paper-module-g.htm) | __waveshare_epd.epd3in0g__ | bw, red, yellow, 4color |
 |  | [3.7inch e-Paper HAT](https://www.waveshare.com/3.7inch-e-Paper-HAT.htm) | __waveshare_epd.epd3in7__ | gray4 |
 |  | [4.01inch 7 color e-Paper HAT](https://www.waveshare.com/4.01inch-e-paper-hat-f.htm) | waveshare_epd.epd4in01f | bw, color |
 |  | [4.2inch e-Paper Module](https://www.waveshare.com/4.2inch-e-Paper-Module.htm) |waveshare_epd.epd4in2 | bw |
 |  | [4.2inch e-Paper Module B](https://www.waveshare.com/4.2inch-e-Paper-Module-B.htm) |waveshare_epd.epd4in2b <br> waveshare_epd.epd4in2b_V2 | bw, red |
 |  | [4.2inch e-Paper Module C](https://www.waveshare.com/4.2inch-e-Paper-Module-C.htm) | __waveshare_epd.epd4in2c__ | bw, yellow |
-|  | 4.37inch e-Paper Module G | waveshare_epd.epd4in37g | bw, color4 |
+|  | 4.37inch e-Paper Module G | waveshare_epd.epd4in37g | bw, red, yellow, 4color |
 |  | [5.65inch e-Paper Module F](https://www.waveshare.com/5.65inch-e-Paper-Module-F.htm) |__waveshare_epd.epd5in65f__ | bw, color |
 |  | [5.83inch e-Paper HAT](https://www.waveshare.com/5.83inch-e-Paper-HAT.htm) |waveshare_epd.epd5in83 <br> waveshare_epd.epd5in83_V2 | bw |
 |  | [5.83inch e-Paper HAT B](https://www.waveshare.com/5.83inch-e-Paper-HAT-B.htm) |waveshare_epd.epd5in83b <br> waveshare_epd.epd5in83b_V2 | bw, red |
 |  | [5.83inch e-Paper HAT C](https://www.waveshare.com/5.83inch-e-Paper-HAT-C.htm) | __waveshare_epd.epd5in83c__ | bw, yellow |
 |  | [6inch e-Ink Display](https://www.waveshare.com/6inch-e-paper-hat.htm) | waveshare_epd.it8951 | bw |
-|  | [7.3inch e-Paper HAT G](https://www.waveshare.com/7.3inch-e-paper-hat-g.htm) | waveshare_epd.epd7in3g | bw, color4 |
+|  | [7.3inch e-Paper HAT G](https://www.waveshare.com/7.3inch-e-paper-hat-g.htm) | waveshare_epd.epd7in3g | bw, red, yellow, 4color |
 |  | [7.5inch e-Paper HAT](https://www.waveshare.com/7.5inch-e-Paper-HAT.htm) | waveshare_epd.epd7in5 | bw |
 |  | [7.5inch e-Paper HAT V2](https://www.waveshare.com/7.5inch-e-Paper-HAT.htm) | __waveshare_epd.epd7in5_V2__ | bw |
 |  | [7.5inch HD e-Paper HAT](https://www.waveshare.com/7.5inch-HD-e-Paper-HAT.htm) |waveshare_epd.epd7in5_HD | bw |

--- a/README.md
+++ b/README.md
@@ -128,10 +128,12 @@ Below is a list of displays currently implemented in the library. The Omni Devic
 |  | [1.54inch E-Ink display module](https://www.waveshare.com/1.54inch-e-Paper-Module.htm) | waveshare_epd.epdlin54 <br> waveshare_epd.epdlin54_V2 | bw |
 |  | [1.54inch e-Paper Module B](https://www.waveshare.com/1.54inch-e-Paper-Module-B.htm) | waveshare_epd.epdlin54b <br> waveshare_epd.epdlin54b_V2 | bw, red |
 |  | [1.54inch e-Paper Module C ](https://www.waveshare.com/1.54inch-e-Paper-Module-C.htm) | waveshare_epd.epdlin54c | bw, yellow |
+|  | [1.64inch e-Paper Module G ](https://www.waveshare.com/1.64inch-e-paper-module-g.htm) | waveshare_epd.epd1in64g | bw, color4 |
 |  | [2.13inch e-Paper HAT](https://www.waveshare.com/2.13inch-e-Paper-HAT.htm) | waveshare_epd.epd2in13 <br>  waveshare_epd.epd2in13_V2 | bw |
 |  | [2.13inch e-Paper HAT B](https://www.waveshare.com/2.13inch-e-Paper-HAT-B.htm) | waveshare_epd.epd2in13b <br> waveshare_epd.epd2in13b_V3 | bw, red |
 |  | [2.13inch e-Paper HAT C ](https://www.waveshare.com/2.13inch-e-Paper-HAT-C.htm) | waveshare_epd.epd2in13c | bw, yellow |
 |  | [2.13inch e-Paper HAT D](https://www.waveshare.com/2.13inch-e-Paper-HAT-D.htm) | waveshare_epd.epd2in13d | bw |
+|  | 2.36inch e-Paper Module G | waveshare_epd.epd2in66 | bw, color4 |
 |  | [2.66inch e-Paper Module](https://www.waveshare.com/2.66inch-e-Paper-Module.htm) | waveshare_epd.epd2in66 | bw |
 |  | [2.66inch e-Paper Module B](https://www.waveshare.com/2.66inch-e-Paper-Module-B.htm) | waveshare_epd.epd2in66b | bw, red |
 |  | [2.7inch e-Paper HAT](https://www.waveshare.com/2.7inch-e-Paper-HAT.htm) | __waveshare_epd.epd2in7__ | bw |
@@ -140,16 +142,19 @@ Below is a list of displays currently implemented in the library. The Omni Devic
 |  | [2.9inch e-Paper Module B](https://www.waveshare.com/2.9inch-e-Paper-Module-B.htm) | waveshare_epd.epd2in9b <br> waveshare_epd.epd2in9b_V3 | bw, red |
 |  | [2.9inch e-Paper Module C](https://www.waveshare.com/2.9inch-e-Paper-Module-C.htm) | waveshare_epd.epd2in9c | bw, yellow |
 |  | [2.9inch e-Paper HAT D](https://www.waveshare.com/2.9inch-e-Paper-HAT-D.htm) | waveshare_epd.epd2in9d | bw |
+|  | [3inch e-Paper Module G](https://www.waveshare.com/3inch-e-paper-module-g.htm) | waveshare_epd.epd3in0g | bw, color4 |
 |  | [3.7inch e-Paper HAT](https://www.waveshare.com/3.7inch-e-Paper-HAT.htm) | __waveshare_epd.epd3in7__ | gray4 |
 |  | [4.01inch 7 color e-Paper HAT](https://www.waveshare.com/4.01inch-e-paper-hat-f.htm) | waveshare_epd.epd4in01f | bw, color |
 |  | [4.2inch e-Paper Module](https://www.waveshare.com/4.2inch-e-Paper-Module.htm) |waveshare_epd.epd4in2 | bw |
 |  | [4.2inch e-Paper Module B](https://www.waveshare.com/4.2inch-e-Paper-Module-B.htm) |waveshare_epd.epd4in2b <br> waveshare_epd.epd4in2b_V2 | bw, red |
 |  | [4.2inch e-Paper Module C](https://www.waveshare.com/4.2inch-e-Paper-Module-C.htm) | __waveshare_epd.epd4in2c__ | bw, yellow |
+|  | 4.37inch e-Paper Module G | waveshare_epd.epd4in37g | bw, color4 |
 |  | [5.65inch e-Paper Module F](https://www.waveshare.com/5.65inch-e-Paper-Module-F.htm) |__waveshare_epd.epd5in65f__ | bw, color |
 |  | [5.83inch e-Paper HAT](https://www.waveshare.com/5.83inch-e-Paper-HAT.htm) |waveshare_epd.epd5in83 <br> waveshare_epd.epd5in83_V2 | bw |
 |  | [5.83inch e-Paper HAT B](https://www.waveshare.com/5.83inch-e-Paper-HAT-B.htm) |waveshare_epd.epd5in83b <br> waveshare_epd.epd5in83b_V2 | bw, red |
 |  | [5.83inch e-Paper HAT C](https://www.waveshare.com/5.83inch-e-Paper-HAT-C.htm) | __waveshare_epd.epd5in83c__ | bw, yellow |
 |  | [6inch e-Ink Display](https://www.waveshare.com/6inch-e-paper-hat.htm) | waveshare_epd.it8951 | bw |
+|  | [7.3inch e-Paper HAT G](https://www.waveshare.com/7.3inch-e-paper-hat-g.htm) | waveshare_epd.epd7in3g | bw, color4 |
 |  | [7.5inch e-Paper HAT](https://www.waveshare.com/7.5inch-e-Paper-HAT.htm) | waveshare_epd.epd7in5 | bw |
 |  | [7.5inch e-Paper HAT V2](https://www.waveshare.com/7.5inch-e-Paper-HAT.htm) | __waveshare_epd.epd7in5_V2__ | bw |
 |  | [7.5inch HD e-Paper HAT](https://www.waveshare.com/7.5inch-HD-e-Paper-HAT.htm) |waveshare_epd.epd7in5_HD | bw |

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Below is a list of displays currently implemented in the library. The Omni Devic
 |  | [2.13inch e-Paper HAT B](https://www.waveshare.com/2.13inch-e-Paper-HAT-B.htm) | waveshare_epd.epd2in13b <br> waveshare_epd.epd2in13b_V3 | bw, red |
 |  | [2.13inch e-Paper HAT C ](https://www.waveshare.com/2.13inch-e-Paper-HAT-C.htm) | waveshare_epd.epd2in13c | bw, yellow |
 |  | [2.13inch e-Paper HAT D](https://www.waveshare.com/2.13inch-e-Paper-HAT-D.htm) | waveshare_epd.epd2in13d | bw |
-|  | 2.36inch e-Paper Module G | waveshare_epd.epd2in66 | bw, color4 |
+|  | 2.36inch e-Paper Module G | waveshare_epd.epd2in36g | bw, color4 |
 |  | [2.66inch e-Paper Module](https://www.waveshare.com/2.66inch-e-Paper-Module.htm) | waveshare_epd.epd2in66 | bw |
 |  | [2.66inch e-Paper Module B](https://www.waveshare.com/2.66inch-e-Paper-Module-B.htm) | waveshare_epd.epd2in66b | bw, red |
 |  | [2.7inch e-Paper HAT](https://www.waveshare.com/2.7inch-e-Paper-HAT.htm) | __waveshare_epd.epd2in7__ | bw |

--- a/src/omni_epd/displays/waveshare_display.py
+++ b/src/omni_epd/displays/waveshare_display.py
@@ -234,7 +234,7 @@ class WaveshareQuadColorDisplay(WaveshareDisplay):
     # list of all devices - some drivers cover more than one device
     deviceMap = {"epd1in64g": {"driver": "epd1in64g", "modes": ("bw", "color4"), "version": 1},
                  "epd2in36g": {"driver": "epd2in36g", "modes": ("bw", "color4"), "version": 1},
-                 "epd3in0g": {"driver": "epd3in0g", "modes": ("bw", "color4"), "version": 1}
+                 "epd3in0g": {"driver": "epd3in0g", "modes": ("bw", "color4"), "version": 1},
                  "epd4in37g": {"driver": "epd4in37g", "modes": ("bw", "color4"), "version": 1},
                  "epd7in3g": {"driver": "epd3in0g", "modes": ("bw", "color4"), "version": 1}}
 

--- a/src/omni_epd/displays/waveshare_display.py
+++ b/src/omni_epd/displays/waveshare_display.py
@@ -106,7 +106,7 @@ class WaveshareBWDisplay(WaveshareDisplay):
         # device object loaded in parent class
 
         # some devices set the full instruction as the param
-        if(self.deviceMap[deviceName]['lut_init']):
+        if (self.deviceMap[deviceName]['lut_init']):
             self.alt_init_param = self._device.lut_full_update
 
     @staticmethod
@@ -114,7 +114,7 @@ class WaveshareBWDisplay(WaveshareDisplay):
         result = []
 
         # python libs for this might not be installed - that's ok, return nothing
-        if(check_module_installed(WAVESHARE_PKG)):
+        if (check_module_installed(WAVESHARE_PKG)):
             # return a list of all submodules (device types)
             result = [f"{WAVESHARE_PKG}.{n}" for n in WaveshareBWDisplay.deviceMap]
 
@@ -122,7 +122,7 @@ class WaveshareBWDisplay(WaveshareDisplay):
 
     def prepare(self):
         # if device needs an init param
-        if(self.deviceMap[self._device_name]['alt_init']):
+        if (self.deviceMap[self._device_name]['alt_init']):
             self._device.init(self.alt_init_param)
         else:
             self._device.init()
@@ -132,7 +132,7 @@ class WaveshareBWDisplay(WaveshareDisplay):
         self._device.display(self._device.getbuffer(image))
 
     def clear(self):
-        if(self.deviceMap[self._device_name]['alt_clear']):
+        if (self.deviceMap[self._device_name]['alt_clear']):
             # device needs color parameter, hardcode white
             self._device.Clear(0xFF)
         else:
@@ -181,9 +181,9 @@ class WaveshareTriColorDisplay(WaveshareDisplay):
         # set the allowed modes
         self.modes_available = self.deviceMap[deviceName]['modes']
 
-        if(self.mode == 'red'):
+        if (self.mode == 'red'):
             self.palette_filter.append([255, 0, 0])
-        elif(self.mode == 'yellow'):
+        elif (self.mode == 'yellow'):
             self.palette_filter.append([255, 255, 0])
 
     @staticmethod
@@ -191,7 +191,7 @@ class WaveshareTriColorDisplay(WaveshareDisplay):
         result = []
 
         # python libs for this might not be installed - that's ok, return nothing
-        if(check_module_installed(WAVESHARE_PKG)):
+        if (check_module_installed(WAVESHARE_PKG)):
             result = [f"{WAVESHARE_PKG}.{n}" for n in WaveshareTriColorDisplay.deviceMap]
 
         return result
@@ -201,7 +201,7 @@ class WaveshareTriColorDisplay(WaveshareDisplay):
 
     def _display(self, image):
 
-        if(self.mode == 'bw'):
+        if (self.mode == 'bw'):
             # send the black/white image and blank second image (safer since some drivers require data)
             img_white = Image.new('1', (self._device.height, self._device.width), 255)
             self._device.display(self._device.getbuffer(image), self._device.getbuffer(img_white))
@@ -248,7 +248,7 @@ class WaveshareQuadColorDisplay(WaveshareDisplay):
         # set the allowed modes
         self.modes_available = self.deviceMap[deviceName]['modes']
 
-        if(self.mode == 'color4'):
+        if (self.mode == 'color4'):
             self.palette_filter.append([255, 255, 0], [255, 0, 0])
 
     @staticmethod
@@ -256,7 +256,7 @@ class WaveshareQuadColorDisplay(WaveshareDisplay):
         result = []
 
         # python libs for this might not be installed - that's ok, return nothing
-        if(check_module_installed(WAVESHARE_PKG)):
+        if (check_module_installed(WAVESHARE_PKG)):
             result = [f"{WAVESHARE_PKG}.{n}" for n in WaveshareQuadColorDisplay.deviceMap]
 
         return result
@@ -266,7 +266,7 @@ class WaveshareQuadColorDisplay(WaveshareDisplay):
 
     def _display(self, image):
 
-        if(self.mode == 'bw'):
+        if (self.mode == 'bw'):
             # send the black/white image
             self._device.display(self._device.getbuffer(image))
         else:
@@ -300,27 +300,27 @@ class WaveshareGrayscaleDisplay(WaveshareDisplay):
     def get_supported_devices():
         result = []
 
-        if(check_module_installed(WAVESHARE_PKG)):
+        if (check_module_installed(WAVESHARE_PKG)):
             result = [f"{WAVESHARE_PKG}.{n}" for n in WaveshareGrayscaleDisplay.deviceMap]
 
         return result
 
     def prepare(self):
 
-        if(self.mode == "gray4"):
+        if (self.mode == "gray4"):
             self._device.Init_4Gray()
         else:
             self._device.init()
 
     def _display(self, image):
         # no need to adjust image, done in waveshare lib
-        if(self.mode == "gray4"):
+        if (self.mode == "gray4"):
             self._device.display_4Gray(self._device.getbuffer_4Gray(image))
         else:
             self._device.display(self._device.getbuffer(image))
 
     def clear(self):
-        if(self.deviceMap[self._device_name]['alt_clear']):
+        if (self.deviceMap[self._device_name]['alt_clear']):
             self._device.Clear(0xFF)  # use white for clear
         else:
             self._device.Clear()
@@ -350,7 +350,7 @@ class Waveshare3in7Display(WaveshareDisplay):
     def get_supported_devices():
         result = []
 
-        if(check_module_installed(WAVESHARE_PKG)):
+        if (check_module_installed(WAVESHARE_PKG)):
             result = [f"{WAVESHARE_PKG}.epd3in7"]
 
         return result
@@ -383,7 +383,7 @@ class Waveshare102inDisplay(WaveshareDisplay):
     def get_supported_devices():
         result = []
 
-        if(check_module_installed(WAVESHARE_PKG)):
+        if (check_module_installed(WAVESHARE_PKG)):
             result = [f"{WAVESHARE_PKG}.epd1in02"]
 
         return result
@@ -424,7 +424,7 @@ class WaveshareMultiColorDisplay(WaveshareDisplay):
     def get_supported_devices():
         result = []
 
-        if(check_module_installed(WAVESHARE_PKG)):
+        if (check_module_installed(WAVESHARE_PKG)):
             result = [f"{WAVESHARE_PKG}.{n}" for n in WaveshareMultiColorDisplay.deviceList]
 
         return result
@@ -434,7 +434,7 @@ class WaveshareMultiColorDisplay(WaveshareDisplay):
 
     def _display(self, image):
         # driver takes care of filtering when in color mode
-        if(self.mode == 'bw'):
+        if (self.mode == 'bw'):
             image = self._filterImage(image)
 
         self._device.display(self._device.getbuffer(image))

--- a/src/omni_epd/displays/waveshare_display.py
+++ b/src/omni_epd/displays/waveshare_display.py
@@ -222,6 +222,59 @@ class WaveshareTriColorDisplay(WaveshareDisplay):
             # send to display
             self._device.display(self._device.getbuffer(img_black), self._device.getbuffer(img_color))
 
+class WaveshareQuadColorDisplay(WaveshareDisplay):
+    """
+    This class is for the Waveshare displays that support 4 colors
+    white/black/yellow/red
+    https://github.com/waveshare/e-Paper
+    """
+
+    max_colors = 4
+
+    # list of all devices - some drivers cover more than one device
+    deviceMap = {"epd1in64g": {"driver": "epd1in64g", "modes": ("bw", "color4"), "version": 1},
+                 "epd2in36g": {"driver": "epd2in36g", "modes": ("bw", "color4"), "version": 1},
+                 "epd3in0g": {"driver": "epd3in0g", "modes": ("bw", "color4"), "version": 1}
+                 "epd4in37g": {"driver": "epd4in37g", "modes": ("bw", "color4"), "version": 1},
+                 "epd7in3g": {"driver": "epd3in0g", "modes": ("bw", "color4"), "version": 1}}
+
+    def __init__(self, deviceName, config):
+        driverName = self.deviceMap[deviceName]['driver']
+        super().__init__(driverName, config)
+
+        # device object loaded in parent class
+
+        # set the allowed modes
+        self.modes_available = self.deviceMap[deviceName]['modes']
+
+        if(self.mode == 'color4'):
+            self.palette_filter.append([255, 255, 0], [255, 0, 0])
+
+    @staticmethod
+    def get_supported_devices():
+        result = []
+
+        # python libs for this might not be installed - that's ok, return nothing
+        if(check_module_installed(WAVESHARE_PKG)):
+            result = [f"{WAVESHARE_PKG}.{n}" for n in WaveshareQuadColorDisplay.deviceMap]
+
+        return result
+
+    def prepare(self):
+        self._device.init()
+
+    def _display(self, image):
+
+        if(self.mode == 'bw'):
+            # send the black/white image
+            self._device.display(self._device.getbuffer(image))
+        else:
+            # apply the color filter to get a 4 color image
+            image = self._filterImage(image)
+
+            # send to display
+            self._device.display(self._device.getbuffer(image))
+
 
 class WaveshareGrayscaleDisplay(WaveshareDisplay):
     """
@@ -359,7 +412,7 @@ class WaveshareMultiColorDisplay(WaveshareDisplay):
     max_colors = 7
     modes_available = ('bw', 'color')
 
-    deviceList = ["epd5in65f", "epd4in01f"]
+    deviceList = ["epd5in65f"f", "epd4in01f"]
 
     def __init__(self, deviceName, config):
         super().__init__(deviceName, config)

--- a/src/omni_epd/displays/waveshare_display.py
+++ b/src/omni_epd/displays/waveshare_display.py
@@ -222,6 +222,7 @@ class WaveshareTriColorDisplay(WaveshareDisplay):
             # send to display
             self._device.display(self._device.getbuffer(img_black), self._device.getbuffer(img_color))
 
+
 class WaveshareQuadColorDisplay(WaveshareDisplay):
     """
     This class is for the Waveshare displays that support 4 colors
@@ -412,7 +413,7 @@ class WaveshareMultiColorDisplay(WaveshareDisplay):
     max_colors = 7
     modes_available = ('bw', 'color')
 
-    deviceList = ["epd5in65f"f", "epd4in01f"]
+    deviceList = ["epd5in65f", "epd4in01f"]
 
     def __init__(self, deviceName, config):
         super().__init__(deviceName, config)

--- a/src/omni_epd/displays/waveshare_display.py
+++ b/src/omni_epd/displays/waveshare_display.py
@@ -267,8 +267,9 @@ class WaveshareQuadColorDisplay(WaveshareDisplay):
         self._device.init()
 
     def _display(self, image):
-        # apply the color filter
-        image = self._filterImage(image)
+        # driver takes care of filtering when in 4color mode
+        if (self.mode != '4color'):
+            image = self._filterImage(image)
 
         # send to display
         self._device.display(self._device.getbuffer(image))

--- a/src/omni_epd/displays/waveshare_display.py
+++ b/src/omni_epd/displays/waveshare_display.py
@@ -229,15 +229,16 @@ class WaveshareQuadColorDisplay(WaveshareDisplay):
     white/black/yellow/red
     https://github.com/waveshare/e-Paper
     """
-
+    modes_available = ("bw", "red", "yellow", "4color")
     max_colors = 4
+    mode = "4color"
 
     # list of all devices - some drivers cover more than one device
-    deviceMap = {"epd1in64g": {"driver": "epd1in64g", "modes": ("bw", "color4"), "version": 1},
-                 "epd2in36g": {"driver": "epd2in36g", "modes": ("bw", "color4"), "version": 1},
-                 "epd3in0g": {"driver": "epd3in0g", "modes": ("bw", "color4"), "version": 1},
-                 "epd4in37g": {"driver": "epd4in37g", "modes": ("bw", "color4"), "version": 1},
-                 "epd7in3g": {"driver": "epd3in0g", "modes": ("bw", "color4"), "version": 1}}
+    deviceMap = {"epd1in64g": {"driver": "epd1in64g", "version": 1},
+                 "epd2in36g": {"driver": "epd2in36g", "version": 1},
+                 "epd3in0g": {"driver": "epd3in0g", "version": 1},
+                 "epd4in37g": {"driver": "epd4in37g", "version": 1},
+                 "epd7in3g": {"driver": "epd3in0g", "version": 1}}
 
     def __init__(self, deviceName, config):
         driverName = self.deviceMap[deviceName]['driver']
@@ -245,11 +246,12 @@ class WaveshareQuadColorDisplay(WaveshareDisplay):
 
         # device object loaded in parent class
 
-        # set the allowed modes
-        self.modes_available = self.deviceMap[deviceName]['modes']
+        # set the palette
+        if (self.mode == '4color' or self.mode == 'yellow'):
+            self.palette_filter.append([255, 255, 0])
 
-        if (self.mode == 'color4'):
-            self.palette_filter.append([255, 255, 0], [255, 0, 0])
+        if (self.mode == '4color' or self.mode == 'red'):
+            self.palette_filter.append([255, 0, 0])
 
     @staticmethod
     def get_supported_devices():
@@ -265,16 +267,11 @@ class WaveshareQuadColorDisplay(WaveshareDisplay):
         self._device.init()
 
     def _display(self, image):
+        # apply the color filter
+        image = self._filterImage(image)
 
-        if (self.mode == 'bw'):
-            # send the black/white image
-            self._device.display(self._device.getbuffer(image))
-        else:
-            # apply the color filter to get a 4 color image
-            image = self._filterImage(image)
-
-            # send to display
-            self._device.display(self._device.getbuffer(image))
+        # send to display
+        self._device.display(self._device.getbuffer(image))
 
 
 class WaveshareGrayscaleDisplay(WaveshareDisplay):


### PR DESCRIPTION
This will add support for Waveshare's new black/white/yellow/red displays.

https://www.waveshare.com/1.64inch-e-paper-module-g.htm
https://www.waveshare.com/3inch-e-paper-module-g.htm
https://www.waveshare.com/7.3inch-e-paper-hat-g.htm

I have a 3-inch on the way to make sure this works.