### PR TITLE
Adds support for Waveshare 2.13in V3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Added
 
 - added link to [pycasso](https://github.com/jezs00/pycasso) in the README. Thanks @jezs00
-- added new display, [Waveshare 7.3in 7 Color](https://www.waveshare.com/7.3inch-e-paper-hat-f.htm) - thanks @evelyndooley
+- new displays, [Waveshare 7.3in 7 Color](https://www.waveshare.com/7.3inch-e-paper-hat-f.htm) - thanks @evelyndooley, [Waveshare 2.13in V3](https://www.waveshare.com/2.13inch-e-paper-hat.htm)
 
 ## Version 0.3.2
 

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Below is a list of displays currently implemented in the library. The Omni Devic
 |  | [1.54inch e-Paper Module B](https://www.waveshare.com/1.54inch-e-Paper-Module-B.htm) | waveshare_epd.epdlin54b <br> waveshare_epd.epdlin54b_V2 | bw, red |
 |  | [1.54inch e-Paper Module C ](https://www.waveshare.com/1.54inch-e-Paper-Module-C.htm) | waveshare_epd.epdlin54c | bw, yellow |
 |  | [1.64inch e-Paper Module G ](https://www.waveshare.com/1.64inch-e-paper-module-g.htm) | waveshare_epd.epd1in64g | bw, red, yellow, 4color |
-|  | [2.13inch e-Paper HAT](https://www.waveshare.com/2.13inch-e-Paper-HAT.htm) | waveshare_epd.epd2in13 <br>  waveshare_epd.epd2in13_V2 | bw |
+|  | [2.13inch e-Paper HAT](https://www.waveshare.com/2.13inch-e-Paper-HAT.htm) | waveshare_epd.epd2in13 <br>  waveshare_epd.epd2in13_V2 <br> __waveshare_epd.epd2in13_V3__ | bw |
 |  | [2.13inch e-Paper HAT B](https://www.waveshare.com/2.13inch-e-Paper-HAT-B.htm) | waveshare_epd.epd2in13b <br> waveshare_epd.epd2in13b_V3 | bw, red |
 |  | [2.13inch e-Paper HAT C ](https://www.waveshare.com/2.13inch-e-Paper-HAT-C.htm) | waveshare_epd.epd2in13c | bw, yellow |
 |  | [2.13inch e-Paper HAT D](https://www.waveshare.com/2.13inch-e-Paper-HAT-D.htm) | waveshare_epd.epd2in13d | bw |

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = omni_epd
-version = 0.3.2
+version = 0.3.3~beta1
 author = Rob Weber
 author_email = robweberjr@gmail.com
 description = An EPD class abstraction to simplify communications across multiple display types.

--- a/src/omni_epd/displays/waveshare_display.py
+++ b/src/omni_epd/displays/waveshare_display.py
@@ -90,6 +90,7 @@ class WaveshareBWDisplay(WaveshareDisplay):
                  "epd2in9d": {"alt_init": False, "lut_init": False, "alt_clear": True, "version": 1},
                  "epd2in13": {"alt_init": True, "lut_init": True, "alt_clear": True, "version": 1},
                  "epd2in13_V2": {"alt_init": True, "lut_init": False, "alt_clear": True, "version": 2},
+                 "epd2in13_V3": {"alt_init": False, "lut_init": False, "alt_clear": True, "version": 1},
                  "epd2in13d": {"alt_init": False, "lut_init": False, "alt_clear": True, "version": 1},
                  "epd2in66": {"alt_init": True, "lut_init": False, "alt_clear": False, "version": 1},
                  "epd5in83": {"alt_init": False, "lut_init": False, "alt_clear": False, "version": 1},


### PR DESCRIPTION
Adds support for the V3 variant of the Waveshare 2.13in EPD. The methods on this are a bit different than the V2 so it's not just a matter of using the same ID for both. 

https://www.waveshare.com/2.13inch-e-paper-hat.htm 