### PR TITLE
Add correct driver for epd7in3g

### DIFF
--- a/src/omni_epd/displays/waveshare_display.py
+++ b/src/omni_epd/displays/waveshare_display.py
@@ -239,7 +239,7 @@ class WaveshareQuadColorDisplay(WaveshareDisplay):
                  "epd2in36g": {"driver": "epd2in36g", "version": 1},
                  "epd3in0g": {"driver": "epd3in0g", "version": 1},
                  "epd4in37g": {"driver": "epd4in37g", "version": 1},
-                 "epd7in3g": {"driver": "epd3in0g", "version": 1}}
+                 "epd7in3g": {"driver": "epd7in3g", "version": 1}}
 
     def __init__(self, deviceName, config):
         driverName = self.deviceMap[deviceName]['driver']


### PR DESCRIPTION
This fixes the wrong resolution for the waveshare_epd.epd7in3g.

Proof:
![PXL_20240624_105905604](https://github.com/robweber/omni-epd/assets/15419390/68f8f26b-69f2-439d-841d-a0f0f608fdd1)
(I would have had fixed this few days ago if I wouldn't have applied the changes to the wrong venv...)