### PR TITLE
Add support for epd7in3e

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ Below is a list of displays currently implemented in the library. The Omni Devic
 |  | [5.83inch e-Paper HAT B](https://www.waveshare.com/5.83inch-e-Paper-HAT-B.htm) |waveshare_epd.epd5in83b <br> waveshare_epd.epd5in83b_V2 | bw, red |
 |  | [5.83inch e-Paper HAT C](https://www.waveshare.com/5.83inch-e-Paper-HAT-C.htm) | __waveshare_epd.epd5in83c__ | bw, yellow |
 |  | [6inch e-Ink Display](https://www.waveshare.com/6inch-e-paper-hat.htm) | waveshare_epd.it8951 | bw, gray16 |
+|  | [7.3inch e-Paper HAT E](https://www.waveshare.com/7.3inch-e-paper-hat-e.htm) | __waveshare_epd.epd7in3e__ | bw, color |
 |  | [7.3inch e-Paper HAT G](https://www.waveshare.com/7.3inch-e-paper-hat-g.htm) | __waveshare_epd.epd7in3g__ | bw, red, yellow, 4color |
 |  | [7.3inch e-Paper HAT F](https://www.waveshare.com/7.3inch-e-paper-hat-f.htm) | waveshare_epd.epd7in3f | bw, color |
 |  | [7.5inch e-Paper HAT](https://www.waveshare.com/7.5inch-e-Paper-HAT.htm) | waveshare_epd.epd7in5 | bw |

--- a/README.md
+++ b/README.md
@@ -213,8 +213,6 @@ __Waveshare__
 
 The [Waveshare device library](https://github.com/waveshareteam/e-Paper) requires that [SPI support](https://www.raspberrypi-spy.co.uk/2014/08/enabling-the-spi-interface-on-the-raspberry-pi/) be enabled on your system prior to use. The `waveshare-epd` module is automatically downloaded and installed as a dependency of this module.
 
-__Please note:__ The version of the Waveshare repo used by this library is a [fork](https://github.com/mendhak/waveshare-epaper-sample) of the official repository. This is due to the official repo not having [correct detection support](https://github.com/waveshareteam/e-Paper/pull/307/) for Raspberry Pi OS 12 (Bookworm). Once the official repo is updated the source for the Waveshare drivers will be moved back to the official repo.
-
 __IT8951__
 
 IT8951 devices, such as the [Waveshare 6in EPD](https://www.waveshare.com/6inch-e-paper-hat.htm), are supported via a [separately maintained Python module](https://github.com/GregDMeyer/IT8951) from Greg Kahanamoku-Meyer. This module and it's requirements are downloaded as part of omni-epd setup.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 
 dependencies = [
   "Pillow>=9.1.0",
-  "waveshare-epd @ git+https://github.com/mendhak/waveshare-epaper-sample.git#subdirectory=RaspberryPi_JetsonNano/python&egg=waveshare-epd",
+  "waveshare-epd @ git+https://github.com/waveshareteam/e-Paper.git#subdirectory=RaspberryPi_JetsonNano/python&egg=waveshare-epd",
   "inky[rpi]>=1.3.1",
   "IT8951[rpi] @ git+https://github.com/GregDMeyer/IT8951.git"
 ]

--- a/src/omni_epd/displays/waveshare_display.py
+++ b/src/omni_epd/displays/waveshare_display.py
@@ -407,13 +407,14 @@ class WaveshareMultiColorDisplay(WaveshareDisplay):
     This class is for the Waveshare 7 color displays
     https://github.com/waveshareteam/e-Paper/blob/master/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd5in65f.py
     https://github.com/waveshareteam/e-Paper/blob/master/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd4in01f.py
+    https://github.com/waveshareteam/e-Paper/blob/master/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd7in3e.py
     https://github.com/waveshareteam/e-Paper/blob/master/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd7in3f.py
     """
 
     max_colors = 7
     modes_available = ('bw', 'color')
 
-    deviceList = ["epd5in65f", "epd4in01f", "epd7in3f"]
+    deviceList = ["epd5in65f", "epd4in01f", "epd7in3e", "epd7in3f"]
 
     def __init__(self, deviceName, config):
         super().__init__(deviceName, config)


### PR DESCRIPTION
- **Switch back to upstream waveshareteam/e-Paper repo**
- **Add support for waveshare_epd.epd7in3e**
Proper color display is dependent on waveshareteam/e-Paper#363 being merged